### PR TITLE
Performance improvement when using oj instead of to_json

### DIFF
--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -10,7 +10,6 @@ module Sequent
     # Base command
     class BaseCommand
       include ActiveModel::Validations,
-              ActiveModel::Serializers::JSON,
               Sequent::Core::Helpers::Copyable,
               Sequent::Core::Helpers::AttributeSupport,
               Sequent::Core::Helpers::UuidHelper,
@@ -20,8 +19,6 @@ module Sequent
       include Sequent::Core::Helpers::TypeConversionSupport
 
       attrs created_at: DateTime
-
-      self.include_root_in_json = false
 
       def initialize(args = {})
         update_all_attributes args

--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -1,10 +1,12 @@
 require 'active_record'
+require_relative 'sequent_oj'
+
 module Sequent
   module Core
 
     module SerializesCommand
       def command
-        args = Oj.strict_load(command_json, {})
+        args = Sequent::Core::Oj.strict_load(command_json)
         Class.const_get(command_type.to_sym).deserialize_from_json(args)
       end
 
@@ -14,7 +16,7 @@ module Sequent
         self.organization_id = command.organization_id if command.respond_to? :organization_id
         self.user_id = command.user_id if command.respond_to? :user_id
         self.command_type = command.class.name
-        self.command_json = Oj.dump(command.attributes)
+        self.command_json = Sequent::Core::Oj.dump(command.attributes)
       end
     end
 

--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -1,13 +1,8 @@
 require 'active_record'
 module Sequent
   module Core
-    # For storing Sequent::Core::Command in the database using active_record
-    class CommandRecord < ActiveRecord::Base
 
-      self.table_name = "command_records"
-
-      validates_presence_of :command_type, :command_json
-
+    module SerializesCommand
       def command
         args = Oj.strict_load(command_json, {})
         Class.const_get(command_type.to_sym).deserialize_from_json(args)
@@ -19,8 +14,18 @@ module Sequent
         self.organization_id = command.organization_id if command.respond_to? :organization_id
         self.user_id = command.user_id if command.respond_to? :user_id
         self.command_type = command.class.name
-        self.command_json = Oj.dump(command)
+        self.command_json = Oj.dump(command.attributes)
       end
+    end
+
+    # For storing Sequent::Core::Command in the database using active_record
+    class CommandRecord < ActiveRecord::Base
+      include SerializesCommand
+
+      self.table_name = "command_records"
+
+      validates_presence_of :command_type, :command_json
+
     end
   end
 end

--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -9,7 +9,7 @@ module Sequent
       validates_presence_of :command_type, :command_json
 
       def command
-        args = JSON.parse(command_json)
+        args = Oj.strict_load(command_json, {})
         Class.const_get(command_type.to_sym).deserialize_from_json(args)
       end
 
@@ -19,7 +19,7 @@ module Sequent
         self.organization_id = command.organization_id if command.respond_to? :organization_id
         self.user_id = command.user_id if command.respond_to? :user_id
         self.command_type = command.class.name
-        self.command_json = command.to_json.to_s
+        self.command_json = Oj.dump(command)
       end
     end
   end

--- a/lib/sequent/core/core.rb
+++ b/lib/sequent/core/core.rb
@@ -1,3 +1,4 @@
+require_relative 'sequent_oj'
 require_relative 'helpers/helpers'
 require_relative 'record_sessions/record_sessions'
 require_relative 'transactions/transactions'

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -29,7 +29,7 @@ module Sequent
       end
       protected
       def payload_variables
-        %w{@aggregate_id @sequence_number @created_at @underscored}
+        %w{@aggregate_id @sequence_number @created_at}
       end
 
     end

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -22,7 +22,10 @@ module Sequent
 
       def payload
         result = {}
-        instance_variables.reject { |k| payload_variables.include?(k.to_s) }.each do |k|
+        instance_variables
+          .reject { |k| payload_variables.include?(k.to_s) }
+          .select { |k| attributes.keys.include?(to_attribute_name(k))}
+          .each do |k|
           result[k.to_s[1 .. -1].to_sym] = instance_variable_get(k)
         end
         result
@@ -30,6 +33,11 @@ module Sequent
       protected
       def payload_variables
         %w{@aggregate_id @sequence_number @created_at}
+      end
+
+      private
+      def to_attribute_name(instance_variable_name)
+        instance_variable_name.to_s.gsub('@', '').to_sym
       end
 
     end

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -10,10 +10,8 @@ module Sequent
       include Sequent::Core::Helpers::StringSupport,
               Sequent::Core::Helpers::EqualSupport,
               Sequent::Core::Helpers::AttributeSupport,
-              Sequent::Core::Helpers::Copyable,
-              ActiveModel::Serializers::JSON
+              Sequent::Core::Helpers::Copyable
       attrs aggregate_id: String, sequence_number: Integer, created_at: DateTime
-      self.include_root_in_json = false
 
       def initialize(args = {})
         update_all_attributes args

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -37,7 +37,7 @@ module Sequent
 
       private
       def to_attribute_name(instance_variable_name)
-        instance_variable_name.to_s.gsub('@', '').to_sym
+        instance_variable_name[1 .. -1].to_sym
       end
 
     end

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -24,7 +24,7 @@ module Sequent
         result = {}
         instance_variables
           .reject { |k| payload_variables.include?(k.to_s) }
-          .select { |k| attributes.keys.include?(to_attribute_name(k))}
+          .select { |k| self.class.types.keys.include?(to_attribute_name(k))}
           .each do |k|
           result[k.to_s[1 .. -1].to_sym] = instance_variable_get(k)
         end

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -23,7 +23,7 @@ module Sequent
       def payload
         result = {}
         instance_variables
-          .reject { |k| payload_variables.include?(k.to_s) }
+          .reject { |k| payload_variables.include?(k) }
           .select { |k| self.class.types.keys.include?(to_attribute_name(k))}
           .each do |k|
           result[k.to_s[1 .. -1].to_sym] = instance_variable_get(k)
@@ -32,7 +32,7 @@ module Sequent
       end
       protected
       def payload_variables
-        %w{@aggregate_id @sequence_number @created_at}
+        %i{@aggregate_id @sequence_number @created_at}
       end
 
       private
@@ -53,7 +53,7 @@ module Sequent
 
       protected
       def payload_variables
-        super << "@organization_id"
+        super << :"@organization_id"
       end
 
     end

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -14,7 +14,7 @@ module Sequent
 
 
       def event
-        payload = Oj.strict_load(event_json)
+        payload = Oj.strict_load(event_json, {})
         Class.const_get(event_type.to_sym).deserialize_from_json(payload)
       end
 
@@ -24,7 +24,7 @@ module Sequent
         self.organization_id = event.organization_id if event.respond_to?(:organization_id)
         self.event_type = event.class.name
         self.created_at = event.created_at
-        self.event_json = event.to_json.to_s
+        self.event_json = Oj.dump(event)
       end
 
     end

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -1,5 +1,5 @@
-require 'oj'
 require 'active_record'
+require_relative 'sequent_oj'
 
 module Sequent
   module Core
@@ -7,7 +7,7 @@ module Sequent
     module SerializesEvent
 
       def event
-        payload = Oj.strict_load(self.event_json, {})
+        payload = Sequent::Core::Oj.strict_load(self.event_json)
         Class.const_get(self.event_type.to_sym).deserialize_from_json(payload)
       end
 
@@ -17,7 +17,7 @@ module Sequent
         self.organization_id = event.organization_id if event.respond_to?(:organization_id)
         self.event_type = event.class.name
         self.created_at = event.created_at
-        self.event_json = Oj.dump(event.attributes)
+        self.event_json = Sequent::Core::Oj.dump(event.attributes)
       end
 
     end

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -3,7 +3,27 @@ require 'active_record'
 
 module Sequent
   module Core
+
+    module SerializesEvent
+
+      def event
+        payload = Oj.strict_load(self.event_json, {})
+        Class.const_get(self.event_type.to_sym).deserialize_from_json(payload)
+      end
+
+      def event=(event)
+        self.aggregate_id = event.aggregate_id
+        self.sequence_number = event.sequence_number
+        self.organization_id = event.organization_id if event.respond_to?(:organization_id)
+        self.event_type = event.class.name
+        self.created_at = event.created_at
+        self.event_json = Oj.dump(event.attributes)
+      end
+
+    end
+
     class EventRecord < ActiveRecord::Base
+      include SerializesEvent
 
       self.table_name = "event_records"
 
@@ -13,19 +33,6 @@ module Sequent
       validates_numericality_of :sequence_number
 
 
-      def event
-        payload = Oj.strict_load(event_json, {})
-        Class.const_get(event_type.to_sym).deserialize_from_json(payload)
-      end
-
-      def event=(event)
-        self.aggregate_id = event.aggregate_id
-        self.sequence_number = event.sequence_number
-        self.organization_id = event.organization_id if event.respond_to?(:organization_id)
-        self.event_type = event.class.name
-        self.created_at = event.created_at
-        self.event_json = Oj.dump(event)
-      end
 
     end
 

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -1,5 +1,5 @@
-require 'oj'
 require_relative 'event_record'
+require_relative 'sequent_oj'
 
 module Sequent
   module Core
@@ -50,7 +50,7 @@ module Sequent
         event_types = {}
         @record_class.connection.select_all("select event_type, event_json from #{@record_class.table_name} where aggregate_id = '#{aggregate_id}' order by sequence_number asc").map! do |event_hash|
           event_type = event_hash["event_type"]
-          event_json = Oj.strict_load(event_hash["event_json"])
+          event_json = Sequent::Core::Oj.strict_load(event_hash["event_json"])
           unless event_types.has_key?(event_type)
             event_types[event_type] = Class.const_get(event_type.to_sym)
           end
@@ -67,7 +67,7 @@ module Sequent
         event_types = {}
         event_stream.each do |event_hash|
           event_type = event_hash["event_type"]
-          payload = Oj.strict_load(event_hash["event_json"])
+          payload = Sequent::Core::Oj.strict_load(event_hash["event_json"])
           unless event_types.has_key?(event_type)
             event_types[event_type] = Class.const_get(event_type.to_sym)
           end

--- a/lib/sequent/core/helpers/association_validator.rb
+++ b/lib/sequent/core/helpers/association_validator.rb
@@ -24,7 +24,7 @@ module Sequent
             next unless association # since ruby 2.0...?
             value = record.instance_variable_get("@#{association.to_s}")
             if value && incorrect_type?(value, record, association)
-              record.errors[association] = "is not of type #{record.attributes[association]}"
+              record.errors[association] = "is not of type #{record.class.types[association]}"
             elsif value && value.kind_of?(Array)
               item_type = record.class.type_for(association).item_type
               record.errors[association] = "is invalid" if all_valid?(value, item_type)
@@ -37,7 +37,7 @@ module Sequent
         private
 
         def incorrect_type?(value, record, association)
-          !value.kind_of?(Array) && record.respond_to?(:attributes) && !value.kind_of?(record.attributes[association])
+          !value.kind_of?(Array) && record.class.respond_to?(:types) && !value.kind_of?(record.class.types[association])
         end
 
         def all_valid?(value, item_type)

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -109,9 +109,17 @@ EOS
         end
 
 
-        # needed for active module JSON serialization
         def attributes
-          self.class.types
+          hash = HashWithIndifferentAccess.new
+          self.class.types.each do |name, _|
+            value = self.instance_variable_get("@#{name}")
+            hash[name] = if value.respond_to?(:attributes)
+                           value.attributes
+                         else
+                           value
+                         end
+          end
+          hash
         end
 
         def validation_errors(prefix = nil)

--- a/lib/sequent/core/helpers/param_support.rb
+++ b/lib/sequent/core/helpers/param_support.rb
@@ -14,7 +14,7 @@ module Sequent
           def from_params(params = {})
             result = allocate
             params = HashWithIndifferentAccess.new(params)
-            result.attributes.each do |attribute, type|
+            result.class.types.each do |attribute, type|
               value = params[attribute]
 
               next if value.blank?

--- a/lib/sequent/core/helpers/type_conversion_support.rb
+++ b/lib/sequent/core/helpers/type_conversion_support.rb
@@ -10,7 +10,7 @@ module Sequent
       module TypeConversionSupport
         def parse_attrs_to_correct_types
           the_copy = dup
-          the_copy.attributes.each do |name, type|
+          the_copy.class.types.each do |name, type|
             raw_value = the_copy.send("#{name}")
             next if raw_value.nil?
             if raw_value.respond_to?(:parse_attrs_to_correct_types)

--- a/lib/sequent/core/sequent_oj.rb
+++ b/lib/sequent/core/sequent_oj.rb
@@ -1,0 +1,20 @@
+require 'oj'
+
+module Sequent
+  module Core
+    # small wrapper class to centralize oj and its settings.
+    class Oj
+
+      ::Oj.default_options={mode: :compat}
+
+      def self.strict_load(json)
+        ::Oj.strict_load(json, {})
+      end
+
+      def self.dump(obj)
+        ::Oj.dump(obj)
+      end
+
+    end
+  end
+end

--- a/lib/sequent/core/value_object.rb
+++ b/lib/sequent/core/value_object.rb
@@ -35,7 +35,6 @@ module Sequent
       include Sequent::Core::Helpers::TypeConversionSupport
 
       def initialize(args = {})
-        @errors = ActiveModel::Errors.new(self)
         update_all_attributes args
       end
 

--- a/lib/sequent/core/value_object.rb
+++ b/lib/sequent/core/value_object.rb
@@ -31,11 +31,8 @@ module Sequent
               Sequent::Core::Helpers::Copyable,
               Sequent::Core::Helpers::AttributeSupport,
               Sequent::Core::Helpers::ParamSupport,
-              ActiveModel::Serializers::JSON,
               ActiveModel::Validations
       include Sequent::Core::Helpers::TypeConversionSupport
-
-      self.include_root_in_json=false
 
       def initialize(args = {})
         @errors = ActiveModel::Errors.new(self)

--- a/lib/sequent/sequent.rb
+++ b/lib/sequent/sequent.rb
@@ -1,3 +1,7 @@
+require 'oj'
+Oj.default_options={mode: :compat}
+
+
 require_relative 'core/core'
 require_relative 'migrations/migrations'
 require_relative 'test/test'

--- a/lib/sequent/sequent.rb
+++ b/lib/sequent/sequent.rb
@@ -1,7 +1,3 @@
-require 'oj'
-Oj.default_options={mode: :compat}
-
-
 require_relative 'core/core'
 require_relative 'migrations/migrations'
 require_relative 'test/test'

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -61,12 +61,12 @@ module Sequent
 
         private
         def serialize_events(events)
-          events.map { |event| [event.class.name.to_sym, Oj.dump(event)] }
+          events.map { |event| [event.class.name.to_sym, Sequent::Core::Oj.dump(event)] }
         end
 
         def deserialize_events(events)
           events.map do |type, json|
-            Class.const_get(type).deserialize_from_json(Oj.strict_load(json, {}))
+            Class.const_get(type).deserialize_from_json(Sequent::Core::Oj.strict_load(json))
           end
         end
 
@@ -87,7 +87,7 @@ module Sequent
       def then_events *events
         @event_store.stored_events.map(&:class).should == events.map(&:class)
         @event_store.stored_events.zip(events).each do |actual, expected|
-          Oj.strict_load(Oj.dump(actual.payload), {}).should == Oj.strict_load(Oj.dump(expected.payload), {}) if expected
+          Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(actual.payload)).should == Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(expected.payload)) if expected
         end
       end
 

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -61,12 +61,12 @@ module Sequent
 
         private
         def serialize_events(events)
-          events.map { |event| [event.class.name.to_sym, event.to_json] }
+          events.map { |event| [event.class.name.to_sym, Oj.dump(event)] }
         end
 
         def deserialize_events(events)
           events.map do |type, json|
-            Class.const_get(type).deserialize_from_json(JSON.parse(json))
+            Class.const_get(type).deserialize_from_json(Oj.strict_load(json, {}))
           end
         end
 
@@ -87,7 +87,7 @@ module Sequent
       def then_events *events
         @event_store.stored_events.map(&:class).should == events.map(&:class)
         @event_store.stored_events.zip(events).each do |actual, expected|
-          JSON.parse(actual.payload.to_json).should == JSON.parse(expected.payload.to_json) if expected
+          Oj.strict_load(Oj.dump(actual.payload), {}).should == Oj.strict_load(Oj.dump(expected.payload), {}) if expected
         end
       end
 

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -86,4 +86,16 @@ describe Sequent::Core::Event do
     expect(event).to eq other
   end
 
+  context ".attributes" do
+
+    it "ignores non attrs like @valid" do
+      person = Person.new(name: "foo")
+      person.valid?
+      event = TestTenantEvent.new(aggregate_id: "1", sequence_number: 2, organization_id: "3", owner: person)
+      expect(event.attributes[:owner]).to_not have_key(:errors)
+      expect(event.attributes[:owner]).to_not have_key(:validation_context)
+    end
+
+  end
+
 end

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -53,8 +53,8 @@ describe Sequent::Core::Event do
     event = TestTenantEvent.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, owner: person
     )
-    json = Oj.dump(event)
-    other = TestTenantEvent.deserialize_from_json(Oj.strict_load(json, {}))
+    json = Sequent::Core::Oj.dump(event)
+    other = TestTenantEvent.deserialize_from_json(Sequent::Core::Oj.strict_load(json))
     expect(other).to eq event
   end
 
@@ -63,7 +63,7 @@ describe Sequent::Core::Event do
     event = EventWithDate.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, date_of_birth: today
     )
-    other = EventWithDate.deserialize_from_json(Oj.strict_load(Oj.dump(event), {}))
+    other = EventWithDate.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)))
     expect(other).to eq event
   end
 
@@ -71,18 +71,18 @@ describe Sequent::Core::Event do
     event = EventWithUnknownAttributeType.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, name: FooType.new
     )
-    expect { EventWithUnknownAttributeType.deserialize_from_json(Oj.strict_load(Oj.dump(event), {})) }.to raise_exception(NoMethodError)
+    expect { EventWithUnknownAttributeType.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))) }.to raise_exception(NoMethodError)
   end
 
   it "converts symbols" do
     event = EventWithSymbol.new(aggregate_id: 123, sequence_number: 7, organization_id: "bar", status: :foo)
-    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event), {}))
+    other = EventWithSymbol.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)))
     expect(event).to eq other
   end
 
   it "deserializes nil symbols" do
     event = EventWithSymbol.new(aggregate_id: 123, organization_id: "bar", sequence_number: 7)
-    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event), {}))
+    other = EventWithSymbol.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)))
     expect(event).to eq other
   end
 

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -53,8 +53,8 @@ describe Sequent::Core::Event do
     event = TestTenantEvent.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, owner: person
     )
-    json = event.to_json
-    other = TestTenantEvent.deserialize_from_json(ActiveSupport::JSON.decode(json))
+    json = Oj.dump(event)
+    other = TestTenantEvent.deserialize_from_json(Oj.strict_load(json))
     expect(other).to eq event
   end
 
@@ -63,7 +63,7 @@ describe Sequent::Core::Event do
     event = EventWithDate.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, date_of_birth: today
     )
-    other = EventWithDate.deserialize_from_json(ActiveSupport::JSON.decode(event.to_json))
+    other = EventWithDate.deserialize_from_json(Oj.strict_load(Oj.dump(event)))
     expect(other).to eq event
   end
 
@@ -71,18 +71,18 @@ describe Sequent::Core::Event do
     event = EventWithUnknownAttributeType.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, name: FooType.new
     )
-    expect { EventWithUnknownAttributeType.deserialize_from_json(ActiveSupport::JSON.decode(event.to_json)) }.to raise_exception(NoMethodError)
+    expect { EventWithUnknownAttributeType.deserialize_from_json(Oj.strict_load(Oj.dump(event))) }.to raise_exception(NoMethodError)
   end
 
   it "converts symbols" do
     event = EventWithSymbol.new(aggregate_id: 123, sequence_number: 7, organization_id: "bar", status: :foo)
-    other = EventWithSymbol.deserialize_from_json(ActiveSupport::JSON.decode(event.to_json))
+    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event)))
     expect(event).to eq other
   end
 
   it "deserializes nil symbols" do
     event = EventWithSymbol.new(aggregate_id: 123, organization_id: "bar", sequence_number: 7)
-    other = EventWithSymbol.deserialize_from_json(ActiveSupport::JSON.decode(event.to_json))
+    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event)))
     expect(event).to eq other
   end
 

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -54,7 +54,7 @@ describe Sequent::Core::Event do
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, owner: person
     )
     json = Oj.dump(event)
-    other = TestTenantEvent.deserialize_from_json(Oj.strict_load(json))
+    other = TestTenantEvent.deserialize_from_json(Oj.strict_load(json, {}))
     expect(other).to eq event
   end
 
@@ -63,7 +63,7 @@ describe Sequent::Core::Event do
     event = EventWithDate.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, date_of_birth: today
     )
-    other = EventWithDate.deserialize_from_json(Oj.strict_load(Oj.dump(event)))
+    other = EventWithDate.deserialize_from_json(Oj.strict_load(Oj.dump(event), {}))
     expect(other).to eq event
   end
 
@@ -71,18 +71,18 @@ describe Sequent::Core::Event do
     event = EventWithUnknownAttributeType.new(
       aggregate_id: 123, organization_id: "bar", sequence_number: 7, name: FooType.new
     )
-    expect { EventWithUnknownAttributeType.deserialize_from_json(Oj.strict_load(Oj.dump(event))) }.to raise_exception(NoMethodError)
+    expect { EventWithUnknownAttributeType.deserialize_from_json(Oj.strict_load(Oj.dump(event), {})) }.to raise_exception(NoMethodError)
   end
 
   it "converts symbols" do
     event = EventWithSymbol.new(aggregate_id: 123, sequence_number: 7, organization_id: "bar", status: :foo)
-    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event)))
+    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event), {}))
     expect(event).to eq other
   end
 
   it "deserializes nil symbols" do
     event = EventWithSymbol.new(aggregate_id: 123, organization_id: "bar", sequence_number: 7)
-    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event)))
+    other = EventWithSymbol.deserialize_from_json(Oj.strict_load(Oj.dump(event), {}))
     expect(event).to eq other
   end
 

--- a/spec/lib/sequent/core/serializes_command_spec.rb
+++ b/spec/lib/sequent/core/serializes_command_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Sequent::Core::SerializesCommand do
+
+  class RecordMock
+    include Sequent::Core::SerializesCommand
+    attr_accessor :aggregate_id,
+                  :created_at,
+                  :user_id,
+                  :command_type,
+                  :command_json
+
+  end
+
+  class RecordValueObject < Sequent::Core::ValueObject
+    attrs value: String
+  end
+
+  class RecordCommand < Sequent::Core::Command
+    attrs value: RecordValueObject
+  end
+
+  let(:value_object) { RecordValueObject.new }
+  let(:command) { RecordCommand.new(aggregate_id: "1",
+                                    user_id: "ben en kim",
+                                    value: value_object) }
+
+  describe ".command" do
+    it 'only serializes declared attrs' do
+      # call valid to let AM generate @errors and @validation_context
+      command.valid?
+      record = RecordMock.new
+      record.command = command
+      payload = Oj.strict_load(record.command_json, {})
+      expect(payload).to have_key("aggregate_id")
+      expect(payload).to have_key("value")
+      expect(payload["value"]).to_not have_key("errors")
+      expect(payload["value"]).to have_key("value")
+    end
+  end
+end

--- a/spec/lib/sequent/core/serializes_command_spec.rb
+++ b/spec/lib/sequent/core/serializes_command_spec.rb
@@ -31,7 +31,7 @@ describe Sequent::Core::SerializesCommand do
       command.valid?
       record = RecordMock.new
       record.command = command
-      payload = Oj.strict_load(record.command_json, {})
+      payload = Sequent::Core::Oj.strict_load(record.command_json)
       expect(payload).to have_key("aggregate_id")
       expect(payload).to have_key("value")
       expect(payload["value"]).to_not have_key("errors")

--- a/spec/lib/sequent/core/serializes_event_spec.rb
+++ b/spec/lib/sequent/core/serializes_event_spec.rb
@@ -31,7 +31,7 @@ describe Sequent::Core::SerializesEvent do
       value_object.valid?
       record = RecordMock.new
       record.event = event
-      payload = Oj.strict_load(record.event_json, {})
+      payload = Sequent::Core::Oj.strict_load(record.event_json)
       expect(payload).to have_key("aggregate_id")
       expect(payload).to have_key("sequence_number")
       expect(payload).to have_key("value")

--- a/spec/lib/sequent/core/serializes_event_spec.rb
+++ b/spec/lib/sequent/core/serializes_event_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Sequent::Core::SerializesEvent do
+
+  class RecordMock
+    include Sequent::Core::SerializesEvent
+    attr_accessor :aggregate_id,
+                  :sequence_number,
+                  :event_type,
+                  :created_at,
+                  :event_json
+
+  end
+
+  class RecordValueObject < Sequent::Core::ValueObject
+    attrs value: String
+  end
+
+  class RecordEvent < Sequent::Core::Event
+    attrs value: RecordValueObject
+  end
+
+  let(:value_object) { RecordValueObject.new }
+  let(:event) { RecordEvent.new(aggregate_id: "1",
+                                sequence_number: 2,
+                                value: value_object) }
+
+  describe ".event" do
+    it 'only serializes declared attrs' do
+      # call valid to let AM generate @errors and @validation_context
+      value_object.valid?
+      record = RecordMock.new
+      record.event = event
+      payload = Oj.strict_load(record.event_json, {})
+      expect(payload).to have_key("aggregate_id")
+      expect(payload).to have_key("sequence_number")
+      expect(payload).to have_key("value")
+      expect(payload["value"]).to_not have_key("errors")
+      expect(payload["value"]).to have_key("value")
+    end
+  end
+end

--- a/spec/lib/sequent/core/value_object_spec.rb
+++ b/spec/lib/sequent/core/value_object_spec.rb
@@ -83,6 +83,17 @@ describe Sequent::Core::ValueObject do
     ).to eq CountryList.new({countries: [country]})
   end
 
+  context ".attributes" do
+
+    it "ignores non attrs like @valid" do
+      address = Address.new
+      address.valid?
+      expect(address.attributes).to_not have_key(:errors)
+      expect(address.attributes).to_not have_key(:validation_context)
+    end
+
+  end
+
 end
 
 


### PR DESCRIPTION
Test serializing > 500.000 events to_json:

With to_json: [68921] ms
With oj: [21171 ms]

Removing ActiveSupport::JSON completely as a result calling `valid?` on a `Command` or `ValueObject` will not result in serialized `errors` and `validation_context` attributes.

```
person = Person.new(name: "Kim")
person.valid?
Sequent::Core::Oj.dump(person)
=> "{\"name\":null,\"validation_context\":null,\"errors\":{}}"
Sequent::Core::Oj.dump(person.attributes)
=> "{\"name\":null}"
```

Both `EventRecord` and `CommandRecord` will call `attributes` method on `event` and `command` before persisting.