### PR TITLE
Migrated to latest rspec syntax

### DIFF
--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -85,9 +85,9 @@ module Sequent
       end
 
       def then_events *events
-        @event_store.stored_events.map(&:class).should == events.map(&:class)
+        expect(@event_store.stored_events.map(&:class)).to eq(events.map(&:class))
         @event_store.stored_events.zip(events).each do |actual, expected|
-          Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(actual.payload)).should == Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(expected.payload)) if expected
+          expect(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(actual.payload))).to eq(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(expected.payload))) if expected
         end
       end
 


### PR DESCRIPTION
I've migrated the 'then_events' in command_handler_helpers to use the latest rspec syntax 'cause I was getting the annoying warning running my own test.
