### PR TITLE
Default `handles_message?` implementation

### DIFF
--- a/lib/sequent/core/base_command_handler.rb
+++ b/lib/sequent/core/base_command_handler.rb
@@ -26,6 +26,10 @@ module Sequent
         @repository = repository
       end
 
+      def handles_message?(command)
+        self.class.message_mapping.keys.find { |x| command.is_a? x }
+      end
+
       protected
       def do_with_aggregate(command, clazz, aggregate_id = nil)
         aggregate = @repository.load_aggregate(aggregate_id.nil? ? command.aggregate_id : aggregate_id, clazz)


### PR DESCRIPTION
By default `BaseCommandHandler#handles_message?` returns whether a
command is registered with the `on` DSL syntax of `SelfApplier`.