### PR TITLE
Support `update` on attribute support

### DIFF
--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -122,6 +122,10 @@ EOS
           hash
         end
 
+        def update(changes)
+          self.class.new(attributes.merge(changes))
+        end
+
         def validation_errors(prefix = nil)
           result = errors.to_hash
           self.class.types.each do |field|

--- a/spec/lib/sequent/core/helpers/attribute_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/attribute_support_spec.rb
@@ -417,9 +417,13 @@ describe Sequent::Core::Helpers::AttributeSupport do
           end
 
         end
+
+        context 'update' do
+          it 'updates the object with changes' do
+            expect(FooBar.new(value: 1).update(value: 2).value).to eq(2)
+          end
+        end
       end
     end
-
-
   end
 end


### PR DESCRIPTION
Updating an object with attribute support will return a new instance of
such object with the given changes merged in.