### PR TITLE
Fix warnings about `raise_exception` in specs

### DIFF
--- a/spec/lib/sequent/core/aggregate_repository_spec.rb
+++ b/spec/lib/sequent/core/aggregate_repository_spec.rb
@@ -88,7 +88,7 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it "should raise exception if a aggregate does not exists" do
-    expect { repository.ensure_exists(:foo, InvoiceCreatedEvent) }.to raise_exception
+    expect { repository.ensure_exists(:foo, InvoiceCreatedEvent) }.to raise_exception NameError
   end
 
   it 'contains an aggregate' do

--- a/spec/lib/sequent/core/helpers/type_conversion_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/type_conversion_support_spec.rb
@@ -26,7 +26,7 @@ describe Sequent::Core::Helpers::TypeConversionSupport do
 
     it "fails fast when invalid value" do
       command = CommandWithInteger.new(value: "A")
-      expect { command.parse_attrs_to_correct_types }.to raise_exception
+      expect { command.parse_attrs_to_correct_types }.to raise_exception %q{invalid value for Integer(): "A"}
     end
 
     it "parses to an Integer" do
@@ -142,12 +142,12 @@ describe Sequent::Core::Helpers::TypeConversionSupport do
 
     it "fails when not a valid Date format" do
       command = CommandWithDate.new(value: "2015-01-01")
-      expect { command.parse_attrs_to_correct_types }.to raise_exception
+      expect { command.parse_attrs_to_correct_types }.to raise_exception "invalid date"
     end
 
     it "fails when not a valid Date" do
       command = CommandWithDate.new(value: "31-31-2015")
-      expect { command.parse_attrs_to_correct_types }.to raise_exception
+      expect { command.parse_attrs_to_correct_types }.to raise_exception "invalid date"
     end
 
     it "handles Dates" do
@@ -184,12 +184,12 @@ describe Sequent::Core::Helpers::TypeConversionSupport do
 
     it "fails when not a valid DateTime format" do
       command = CommandWithDateTime.new(value: "06-04-2015T14:42:32+02:00")
-      expect { command.parse_attrs_to_correct_types }.to raise_exception
+      expect { command.parse_attrs_to_correct_types }.to raise_exception "invalid date"
     end
 
     it "fails when not a valid DateTime" do
       command = CommandWithDateTime.new(value: "SSDFGS345345")
-      expect { command.parse_attrs_to_correct_types }.to raise_exception
+      expect { command.parse_attrs_to_correct_types }.to raise_exception "invalid date"
     end
 
     it "handles DateTimes" do


### PR DESCRIPTION
Fixes these kind of warnings:

> WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Instead consider providing a specific error class or message. This message can be supressed by setting: `RSpec::Expectations.configuration.warn_about_potential_false_positives = false`. Called from /Users/daniel/Development/Workspaces/code/sequent/spec/lib/sequent/core/aggregate_repository_spec.rb:91:in `block (2 levels) in <top (required)>'.
