### PR TITLE
Add EventStreamHelpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,20 @@ namespace :snapshot do
 end
 ```
 
+# Testing
+
+Sequent adds some test helpers to help test your event sourced application. Only RSpec is supported at the moment.
+The use of these modules are documented in the source code.
+
+```ruby
+require 'sequent/test'
+
+RSpec.configure do |c|
+  c.include Sequent::Test::CommandHandlerHelpers
+  c.include Sequent::Test::EventStreamHelpers # FactoryGirl is required for these helpers.
+end
+```
+
 # License
 
 Sequent is released under the MIT License.

--- a/lib/sequent/sequent.rb
+++ b/lib/sequent/sequent.rb
@@ -1,6 +1,5 @@
 require_relative 'core/core'
 require_relative 'migrations/migrations'
-require_relative 'test/test'
 require_relative 'configuration'
 
 require 'logger'

--- a/lib/sequent/test.rb
+++ b/lib/sequent/test.rb
@@ -1,0 +1,3 @@
+require_relative 'sequent'
+require_relative 'test/command_handler_helpers'
+require_relative 'test/event_stream_helpers'

--- a/lib/sequent/test/test.rb
+++ b/lib/sequent/test/test.rb
@@ -1,1 +1,0 @@
-require_relative 'command_handler_helpers'


### PR DESCRIPTION
Including test documentation in the README.

```
    ##
    # Use in tests
    #
    # This provides a nice DSL for generating streams of events. FactoryGirl is required when using this helper.
    #
    # Example for Rspec config
    #
    # RSpec.configure do |config|
    #   config.include Sequent::Test::EventStreamHelpers
    # end
    #
    # Then in a spec
    #
    # given_stream_for(aggregate_id: 'X') do |s|
    #   s.group_created owner_aggregate_id: 'Y'
    #   s.group_opened
    #   s.owner_joined_group owner_aggregate_id: 'Y'
    # end
    #
    # Methods on `s` will be FactoryGirl factories. All arguments will be passed on to FactoryGirl's build method.
    # Aggregate ids and sequence numbers will be set automatically.
    #
    # The example above can also be written as follows:
    #
    # events = event_stream(aggregate_id: 'X') do |s|
    #   s.group_created owner_aggregate_id: 'Y'
    #   s.group_opened
    #   s.owner_joined_group owner_aggregate_id: 'Y'
    # end
    #
    # given_events(events)
    #
```