### PR TITLE
Do not raise ActiveRecord::RecordNotFound

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 coverage
 Gemfile.lock
 /TAGS
+.idea

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -33,7 +33,8 @@ module Sequent
       # Returns all events for the aggregate ordered by sequence_number
       #
       def load_events(aggregate_id)
-        stream = stream_record_class.where(aggregate_id: aggregate_id).first!
+        stream = stream_record_class.where(aggregate_id: aggregate_id).first
+        return nil unless stream
         events = event_record_class.connection.select_all(%Q{
 SELECT event_type, event_json
   FROM #{quote_table_name event_record_class.table_name}

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -95,4 +95,15 @@ describe Sequent::Core::EventStore do
       expect(event_store.stream_exists?(aggregate_id)).to eq(false)
     end
   end
+
+  describe "#load_events" do
+    let(:event_store) { Sequent::configuration.event_store }
+    let(:aggregate_id) { "aggregate-#{rand(10000000)}" }
+
+    it 'returns nil for non existing aggregates' do
+      stream, events = event_store.load_events(aggregate_id)
+      expect(stream).to be_nil
+      expect(events).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Before StreamRecord existed the EvenStore raised an AggregateNotFound when it was not found in the EventStore. 