### PR TITLE
Report error for all items in array

### DIFF
--- a/lib/sequent/core/helpers/association_validator.rb
+++ b/lib/sequent/core/helpers/association_validator.rb
@@ -21,6 +21,11 @@ module Sequent
       #
       class AssociationValidator < ActiveModel::Validator
 
+        def initialize(options = {})
+          super
+          raise "Must provide ':associations' to validate" unless options[:associations].present?
+        end
+
         def validate(record)
           associations = options[:associations]
           associations = [associations] unless associations.instance_of?(Array)

--- a/lib/sequent/core/helpers/association_validator.rb
+++ b/lib/sequent/core/helpers/association_validator.rb
@@ -27,7 +27,7 @@ module Sequent
               record.errors[association] = "is not of type #{record.class.types[association]}"
             elsif value && value.kind_of?(Array)
               item_type = record.class.type_for(association).item_type
-              record.errors[association] = "is invalid" if all_valid?(value, item_type)
+              record.errors[association] = "is invalid" unless validate_all(value, item_type).all?
             else
               record.errors[association] = "is invalid" if value && value.invalid?
             end
@@ -40,14 +40,14 @@ module Sequent
           !value.kind_of?(Array) && record.class.respond_to?(:types) && !value.kind_of?(record.class.types[association])
         end
 
-        def all_valid?(value, item_type)
-          value.any? do |v|
-            if v.nil?
-              true
-            elsif v.respond_to? :valid?
-              not v.valid?
+        def validate_all(values, item_type)
+          values.map do |value|
+            if value.nil?
+              false
+            elsif value.respond_to?(:valid?)
+              value.valid?
             else
-              not Sequent::Core::Helpers::ValueValidators.for(item_type).valid_value?(v)
+              Sequent::Core::Helpers::ValueValidators.for(item_type).valid_value?(value)
             end
           end
         end

--- a/lib/sequent/core/helpers/association_validator.rb
+++ b/lib/sequent/core/helpers/association_validator.rb
@@ -6,15 +6,19 @@ module Sequent
       # Validator for associations. Typically used in Sequent::Core::Command,
       # Sequent::Core::Event and Sequent::Core::ValueObjects.
       #
+      # When you define attrs that are also value object or array(..) then this class is
+      # automatically used.
+      #
       # Example:
       #
-      #   class RegisterForTrainingCommand < UpdateCommand
+      #   class RegisterForTrainingCommand < Sequent::Core::Command
       #     attrs trainee: Person
-      #
-      #     validates_presence_of :trainee
-      #     validates_with Sequent::Core::Helpers::AssociationValidator, associations: [:trainee]
-      #
       #   end
+      #
+      # This will register :trainee with the AssociationValidator and is equivilant to
+      #
+      #   validates_with Sequent::Core::AssociationValidator, associations: [:trainee]
+      #
       class AssociationValidator < ActiveModel::Validator
 
         def validate(record)

--- a/lib/sequent/core/helpers/association_validator.rb
+++ b/lib/sequent/core/helpers/association_validator.rb
@@ -21,7 +21,6 @@ module Sequent
           associations = options[:associations]
           associations = [associations] unless associations.instance_of?(Array)
           associations.each do |association|
-            next unless association # since ruby 2.0...?
             value = record.instance_variable_get("@#{association.to_s}")
             if value && incorrect_type?(value, record, association)
               record.errors[association] = "is not of type #{record.class.types[association]}"

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -133,9 +133,8 @@ EOS
             if value.respond_to? :validation_errors
               value.validation_errors.each { |k, v| result["#{field[0].to_s}_#{k.to_s}".to_sym] = v }
             elsif field[1].class == ArrayWithType and value.present?
-              value.select do |val|
-                val.respond_to?(:validation_errors)
-              end
+              value
+              .select { |val| val.respond_to?(:validation_errors) }
               .each_with_index do |val, index|
                 val.validation_errors.each do |k, v|
                   result["#{field[0].to_s}_#{index}_#{k.to_s}".to_sym] = v

--- a/spec/lib/sequent/core/helpers/association_validator_spec.rb
+++ b/spec/lib/sequent/core/helpers/association_validator_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+
+describe Sequent::Core::Helpers::AssociationValidator do
+  let(:options) { {} }
+  let(:subject) { Sequent::Core::Helpers::AssociationValidator.new(options) }
+
+  it "fails when providing no associations" do
+    expect { subject }.to raise_error /Must provide ':associations' to validate/
+  end
+
+  it "fails when provind an empty list of associations" do
+    options[:associations] = []
+    expect { subject }.to raise_error /Must provide ':associations' to validate/
+  end
+
+
+  context "validating an array with simple types" do
+    class ValueObjectWithSimpleTypeAssociations < Sequent::Core::ValueObject
+      attrs numbers: array(Integer)
+    end
+
+    let(:options) { {associations: [:numbers]} }
+    let(:values) { {} }
+    let(:object) { ValueObjectWithSimpleTypeAssociations.new(values) }
+
+    it "can handle nil as arrays" do
+      subject.validate(object)
+      expect(object.errors).to be_empty
+    end
+
+    it "can handle empty arrays" do
+      values[:numbers] = []
+      subject.validate(object)
+      expect(object.errors).to be_empty
+    end
+
+    it "reports an error for nil values in an array" do
+      values[:numbers] = [nil]
+      subject.validate(object)
+      expect(object.errors).to_not be_empty
+    end
+
+    it "reports an error for invalid value in the array" do
+      values[:numbers] = [10, "A", 9]
+      subject.validate(object)
+      expect(object.errors).to_not be_empty
+    end
+
+  end
+
+  context "validating an array with value objects" do
+    class ValueObjectWithInteger < Sequent::Core::ValueObject
+      attrs number: Integer
+    end
+
+    class ValueObjectWithValueObjectAssociations < Sequent::Core::ValueObject
+      attrs numbers: array(ValueObjectWithInteger)
+    end
+
+    let(:options) { {associations: [:numbers]} }
+    let(:values) { {} }
+    let(:object) { ValueObjectWithValueObjectAssociations.new(values) }
+
+    it "can handle nil as arrays" do
+      subject.validate(object)
+      expect(object.errors).to be_empty
+    end
+
+    it "can handle empty arrays" do
+      values[:numbers] = []
+      subject.validate(object)
+      expect(object.errors).to be_empty
+    end
+
+    it "reports an error for nil values in an array" do
+      values[:numbers] = [nil]
+      subject.validate(object)
+      expect(object.errors).to_not be_empty
+    end
+
+    it "reports an error for invalid value in the array" do
+      values[:numbers] = [ValueObjectWithInteger.new(number: "A"), ValueObjectWithInteger.new(number: 1), ValueObjectWithInteger.new(number: "B")]
+      subject.validate(object)
+      expect(object.errors).to_not be_empty
+      expect(object.validation_errors.size).to eq 3
+      expect(object.validation_errors[:numbers]).to_not be_empty
+      expect(object.validation_errors[:numbers_0_number]).to_not be_empty
+      expect(object.validation_errors[:numbers_2_number]).to_not be_empty
+    end
+
+  end
+end

--- a/spec/lib/sequent/core/helpers/attribute_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/attribute_support_spec.rb
@@ -53,23 +53,40 @@ describe Sequent::Core::Helpers::AttributeSupport do
     end
 
     context "arrays" do
+      class TestClassWithRequiredString < Sequent::Core::ValueObject
+        attrs message: String
+        validates_presence_of :message
+      end
+
       class TestClassWithArray < Sequent::Core::ValueObject
-        attrs messages: array(SubTestClass)
+        attrs messages: array(TestClassWithRequiredString)
         validates_presence_of :messages
       end
 
       it "does not create errors for items in an empty array" do
         subject = TestClassWithArray.new(messages: [])
         expect(subject.valid?).to be_falsey
+        expect(subject.validation_errors.size).to eq 1
         expect(subject.validation_errors[:messages]).to_not be_nil
         expect(subject.validation_errors[:"messages_0_message"]).to be_nil
       end
 
       it "creates an error item in array" do
-        subject = TestClassWithArray.new(messages: [SubTestClass.new])
+        subject = TestClassWithArray.new(messages: [NestedTestClass.new])
         expect(subject.valid?).to be_falsey
+        expect(subject.validation_errors.size).to eq 2
         expect(subject.validation_errors[:messages]).to_not be_nil
         expect(subject.validation_errors[:"messages_0_message"]).to_not be_nil
+      end
+
+      it "creates an error for each item in array" do
+        subject = TestClassWithArray.new(messages: [NestedTestClass.new, NestedTestClass.new])
+        expect(subject.valid?).to be_falsey
+        errors = subject.validation_errors
+        expect(errors[:messages]).to_not be_nil
+        expect(errors[:"messages_0_message"]).to_not be_nil
+        expect(errors[:"messages_1_message"]).to_not be_nil
+        expect(errors.size).to eq 3
       end
     end
 


### PR DESCRIPTION
Introduce error reporting for each individual item in an array. Current limitation is that the individual item in the array should be a `Sequent::Core::ValueObject`. Later we can add "simple" types as `Integer`, `DateTime` etc