### PR TITLE
Add test helper (patch) for datetime comparisons

### DIFF
--- a/lib/sequent/test/time_comparison.rb
+++ b/lib/sequent/test/time_comparison.rb
@@ -1,0 +1,40 @@
+module Sequent
+  module Test
+    module DateTimePatches
+      module Normalize
+        def normalize
+          in_time_zone("UTC")
+        end
+      end
+
+      module Compare
+        alias_method :'___<=>', :<=>
+
+        # omit nsec in datetime comparisons
+        def <=>(other)
+          if other && other.is_a?(DateTimePatches::Normalize)
+            result = normalize.iso8601 <=> other.normalize.iso8601
+            return result unless result == 0
+            # use usec here, which *truncates* the nsec (ie. like Postgres)
+            return normalize.usec <=> other.normalize.usec
+          end
+          public_send(:'___<=>', other)
+        end
+      end
+    end
+  end
+end
+
+class Time
+  prepend Sequent::Test::DateTimePatches::Normalize
+  prepend Sequent::Test::DateTimePatches::Compare
+end
+
+class DateTime
+  prepend Sequent::Test::DateTimePatches::Normalize
+  prepend Sequent::Test::DateTimePatches::Compare
+end
+
+class ActiveSupport::TimeWithZone
+  prepend Sequent::Test::DateTimePatches::Normalize
+end

--- a/spec/lib/sequent/test/time_comparison_spec.rb
+++ b/spec/lib/sequent/test/time_comparison_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'sequent/test/time_comparison'
+
+class ActiveSupport::TimeWithZone
+  def self.parse(str)
+    Time.zone.parse(str)
+  end
+end
+
+describe 'Time comparison' do
+  around do |example|
+    Time.zone = 'UTC'
+    example.run
+    Time.zone = nil
+  end
+
+  time_classes = [Time, DateTime, ActiveSupport::TimeWithZone]
+  options = time_classes.product(time_classes)
+
+  nano = '2015-08-14T15:17:23.123456789+00:00'
+  micro = '2015-08-14T15:17:23.123456+00:00'
+
+  time_options = [nano, micro].product([nano, micro])
+
+  options.each do |some_class, other_class|
+    time_options.each do |some_time, other_time|
+      context "given a #{some_class} (#{some_time})" do
+        context "and a #{other_class} (#{other_time})" do
+          it 'is equal' do
+            expect(some_class.parse(some_time)).to eq(other_class.parse(other_time))
+          end
+        end
+      end
+    end
+  end
+
+  context 'when other is nil' do
+    it 'is not equal' do
+      expect(Time.now == nil).to be_falsey
+      expect(DateTime.now == nil).to be_falsey
+      expect(Time.current == nil).to be_falsey
+    end
+  end
+
+  context 'when other is not time related' do
+    it 'is not equal' do
+      expect(Time.now == :test).to be_falsey
+      expect(DateTime.now == :test).to be_falsey
+      expect(Time.current == :test).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
This patch on `Time`, `DateTime` and `ActiveSupport::TimeWithZone` omits nanosecond difference when comparing times. 

Allows you to keep using built-in rspec matchers (such as `eq`) without having to worry about nanosecond differences which are likely to occur when running on a Linux machine or when time objects have been serialized (ie. Postgres) and lost subsecond precision.

Usage:

Just `require 'sequent/test/time_comparision'` in your spec file (or spec_helper.rb), and you're good to go.