### PR TITLE
Provide Rake tasks to ease setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,30 @@ Sequent needs a Postgres database with the event store schema. The current schem
 
 If you have trouble migrating from an older schema, please let us know. We'll be glad to help out.
 
+# Rake Tasks
+
+Sequent provides some Rake tasks to ease setup. To make them available in your project, add
+the following to your `Rakefile`.
+
+```ruby
+begin
+  require 'sequent/rake/tasks'
+  Sequent::Rake::Tasks.new(opts).register!
+rescue LoadError
+  puts 'Sequent tasks are not available'
+end
+```
+
+You *must* pass some options (`opts`) to tell Sequent your configuration.
+
+* `db_config_supplier` — function that takes an environment and returns the database configs for that environment (e.g. `YAML.parse('db/database.yml')`)
+* `environment` — deployment environment (like `RAILS_ENV`) to get the appropriate database config
+* `event_store_schema` — name of the database schema that contains the event store (defaults to `public`)
+* `view_schema` — hash with the `name` `version` and `definition` (path to your `view_schema.rb`) of your view schema
+* `migration_path` — path to your migrations directory (defaults to `db/migrate`)
+
+And you're all set to use the Rake tasks (see `rake -T` for a description).
+
 # Reference Guide
 
 Sequent provides the following concepts from a CQRS and an event sourced application:

--- a/README.md
+++ b/README.md
@@ -67,21 +67,21 @@ If you have trouble migrating from an older schema, please let us know. We'll be
 
 # View Schema
 
-Besides the event store database schema your app needs view projections. These projections are versioned and kept in a different database schema.
+Besides the event store database schema your app needs view projections. Projections are versioned and kept in a different database schema, but in
+the same database.
 
-Sequent provides support to make ActiveRecord use separate connection pools for these schemas. Use `Sequent::Support::BaseViewModel` as
-your base model class and call `Sequent::Support::Database.establish_connections(db_config, view_schema_name)` during initialization.
+Sequent adds support to maintain both schemas in the same database. Set the `schema_search_path` in your database config to your event store schema and
+your view projection schema, respectively. E.g. 'event_store, view_1'.
 
 The view schema is not maintained through migrations but instead is rebuild from recorded events. Therefore, there are no migrations on the view schema.
 Its schema should be provided as a schema definition (e.g. in `db/view_schema.rb`).
 
-Because the view schema needs a different connection (with the view schema on the search path), use the `Sequent::Support::ViewSchema` extension of
-`ActiveRecord::Schema` to define it.
+To load the view schema in a different database schema use the `Sequent::Support::ViewSchema` extension of `ActiveRecord::Schema` to define it.
 
 For example:
 
 ```ruby
-Sequent::Support::ViewSchema.define do
+Sequent::Support::ViewSchema.define(view_projection: Sequent::Support::ViewProjection.new(..)) do
   create_table 'accounts' do |t|
     t.string 'name', null: false
     t.string 'email', null: false
@@ -90,6 +90,13 @@ end
 ```
 
 The support module is not required with sequent automatically. Require `sequent/support` to enable it.
+
+---
+
+Sequent provides support to make ActiveRecord use separate connection pools for these schemas.
+
+Use `Sequent::Support::BaseViewModel` as
+your base model class and call `Sequent::Support::Database.establish_connections(db_config, view_schema_name)` during initialization.
 
 # Rake Tasks
 
@@ -110,7 +117,7 @@ You *must* pass some options (`opts`) to tell Sequent your configuration.
 * `db_config_supplier` — function that takes an environment and returns the database configs for that environment (e.g. `YAML.parse('db/database.yml')`)
 * `environment` — deployment environment (like `RAILS_ENV`) to get the appropriate database config
 * `event_store_schema` — name of the database schema that contains the event store (defaults to `public`)
-* `view_schema` — hash with the `name` `version` and `definition` (path to your `view_schema.rb`) of your view schema
+* `view_projection` — a `Sequent::Support::ViewProjection` that specifies your view schema
 * `migration_path` — path to your ActiveRecord migrations directory (defaults to `db/migrate`)
 
 And you're all set to use the Rake tasks (see `rake -T` for a description).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Sequent::Support::ViewSchema.define do
 end
 ```
 
+The support module is not required with sequent automatically. Require `sequent/support` to enable it.
+
 # Rake Tasks
 
 Sequent provides some Rake tasks to ease setup. To make them available in your project, add

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -27,6 +27,10 @@ module Sequent
       @instance = new
     end
 
+    def self.restore(configuration)
+      @instance = configuration
+    end
+
     def initialize
       self.command_handlers = []
       self.command_filters = []

--- a/lib/sequent/rake/tasks.rb
+++ b/lib/sequent/rake/tasks.rb
@@ -95,7 +95,7 @@ module Sequent
       end
 
       def view_projection
-        @view_projection ||= Sequent::Support::ViewProjection.new(options.fetch(:view_schema))
+        options.fetch(:view_projection)
       end
     end
   end

--- a/lib/sequent/rake/tasks.rb
+++ b/lib/sequent/rake/tasks.rb
@@ -1,0 +1,104 @@
+require 'active_record'
+require 'rake'
+require 'rake/tasklib'
+
+require 'sequent/support'
+
+module Sequent
+  module Rake
+    class Tasks < ::Rake::TaskLib
+      include ::Rake::DSL
+
+      DEFAULT_OPTIONS = {
+        migrations_path: 'db/migrate',
+        event_store_schema: 'public'
+      }
+
+      attr_reader :options
+
+      def initialize(options)
+        @options = DEFAULT_OPTIONS.merge(options)
+      end
+
+      def register!
+        register_db_tasks!
+        register_view_schema_tasks!
+      end
+
+      def register_db_tasks!
+        namespace :db do
+          desc 'Create the database'
+          task :create do
+            current_environments.each do |env|
+              env_db = db_config(env)
+              puts "Create database #{env_db['database']}"
+              Sequent::Support::Database.create!(env_db)
+            end
+          end
+
+          desc 'Drop the database'
+          task :drop do
+            current_environments.each do |env|
+              env_db = db_config(env)
+              puts "Drop database #{env_db['database']}"
+              Sequent::Support::Database.drop!(env_db)
+            end
+          end
+
+          task :establish_connection do
+            env_db = db_config(options.fetch(:environment))
+            Sequent::Support::Database.establish_connections(env_db, view_projection.schema_name)
+          end
+
+          desc 'Migrate the database'
+          task migrate: :establish_connection do
+            database.create_schema_if_not_exists!(options.fetch(:event_store_schema))
+            database.migrate(options.fetch(:migrations_path))
+          end
+        end
+      end
+
+      def register_view_schema_tasks!
+        namespace :view_schema do
+          desc 'Build the view schema'
+          task build: :'db:establish_connection' do
+            if database.schema_exists?(view_projection.schema_name)
+              puts "View version #{view_projection.version} already exists; no need to build it"
+            else
+              database.create_schema!(view_projection.schema_name)
+              view_projection.build!
+            end
+          end
+
+          desc 'Drop the view schema'
+          task drop: :'db:establish_connection' do
+            database.drop_schema!(view_projection.schema_name)
+          end
+        end
+      end
+
+      private
+
+      def current_environments
+        envs = [options.fetch(:environment)]
+        envs << 'test' if @env == 'development'
+        envs
+      end
+
+      def database
+        @database ||= Sequent::Support::Database.new
+      end
+
+      def db_config(environment)
+        options.fetch(:db_config_supplier)[environment] or fail "No database config for #{environment}"
+      end
+
+      def view_projection
+        schema_config = options.fetch(:view_schema)
+        @view_projection ||= Sequent::Support::ViewProjection.new(
+          schema_config.fetch(:name), schema_config.fetch(:version), schema_config.fetch(:definition)
+        )
+      end
+    end
+  end
+end

--- a/lib/sequent/rake/tasks.rb
+++ b/lib/sequent/rake/tasks.rb
@@ -47,7 +47,7 @@ module Sequent
 
           task :establish_connection do
             env_db = db_config(options.fetch(:environment))
-            Sequent::Support::Database.establish_connections(env_db, view_projection.schema_name)
+            Sequent::Support::Database.establish_connection(env_db)
           end
 
           desc 'Migrate the database'

--- a/lib/sequent/rake/tasks.rb
+++ b/lib/sequent/rake/tasks.rb
@@ -80,8 +80,9 @@ module Sequent
       private
 
       def current_environments
-        envs = [options.fetch(:environment)]
-        envs << 'test' if @env == 'development'
+        environment = options.fetch(:environment)
+        envs = [environment]
+        envs << 'test' if environment == 'development'
         envs
       end
 
@@ -94,10 +95,7 @@ module Sequent
       end
 
       def view_projection
-        schema_config = options.fetch(:view_schema)
-        @view_projection ||= Sequent::Support::ViewProjection.new(
-          schema_config.fetch(:name), schema_config.fetch(:version), schema_config.fetch(:definition)
-        )
+        @view_projection ||= Sequent::Support::ViewProjection.new(options.fetch(:view_schema))
       end
     end
   end

--- a/lib/sequent/rake/tasks.rb
+++ b/lib/sequent/rake/tasks.rb
@@ -52,7 +52,7 @@ module Sequent
 
           desc 'Migrate the database'
           task migrate: :establish_connection do
-            database.create_schema_if_not_exists!(options.fetch(:event_store_schema))
+            database.create_schema!(options.fetch(:event_store_schema))
             database.migrate(options.fetch(:migrations_path))
           end
         end

--- a/lib/sequent/support.rb
+++ b/lib/sequent/support.rb
@@ -1,4 +1,3 @@
 require_relative 'support/database'
 require_relative 'support/view_projection'
-require_relative 'support/base_view_model'
 require_relative 'support/view_schema'

--- a/lib/sequent/support.rb
+++ b/lib/sequent/support.rb
@@ -1,0 +1,4 @@
+require_relative 'support/database'
+require_relative 'support/view_projection'
+require_relative 'support/base_view_model'
+require_relative 'support/view_schema'

--- a/lib/sequent/support/base_view_model.rb
+++ b/lib/sequent/support/base_view_model.rb
@@ -1,8 +1,0 @@
-module Sequent
-  module Support
-    # Base view model to manage the view connection pool
-    class BaseViewModel < ActiveRecord::Base
-      self.abstract_class = true
-    end
-  end
-end

--- a/lib/sequent/support/base_view_model.rb
+++ b/lib/sequent/support/base_view_model.rb
@@ -1,0 +1,8 @@
+module Sequent
+  module Support
+    # Base view model to manage the view connection pool
+    class BaseViewModel < ActiveRecord::Base
+      self.abstract_class = true
+    end
+  end
+end

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -37,15 +37,11 @@ module Sequent
       end
 
       def create_schema!(schema)
-        sql = "CREATE SCHEMA #{schema}"
+        sql = "CREATE SCHEMA IF NOT EXISTS #{schema}"
         if user = ActiveRecord::Base.connection_config[:username]
           sql += " AUTHORIZATION #{user}"
         end
         ActiveRecord::Base.connection.execute(sql)
-      end
-
-      def create_schema_if_not_exists!(schema)
-        create_schema!(schema) unless schema_exists?(schema)
       end
 
       def drop_schema!(schema)

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -18,16 +18,12 @@ module Sequent
         ActiveRecord::Base.connection.drop_database(db_config['database'])
       end
 
-      def self.establish_connections(db_config, view_schema_name)
-        Sequent::Support::BaseViewModel.establish_connection(
-          db_config.merge('schema_search_path' => view_schema_name)
-        )
+      def self.establish_connection(db_config)
         ActiveRecord::Base.establish_connection(db_config)
       end
 
       def self.disconnect!
         ActiveRecord::Base.connection_pool.disconnect!
-        Sequent::Support::BaseViewModel.connection_pool.disconnect!
       end
 
       def schema_exists?(schema)

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -46,7 +46,7 @@ module Sequent
 
       def drop_schema!(schema)
         ActiveRecord::Base.connection.execute(
-          "DROP SCHEMA #{schema} CASCADE"
+          "DROP SCHEMA IF EXISTS #{schema} CASCADE"
         )
       end
 

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -1,0 +1,63 @@
+module Sequent
+  module Support
+    # Offers support operations for a postgres database.
+    #
+    # Class methods do establish their own database connections (and therefore
+    # take in a database configuration). Instance methods assume that a database
+    # connection yet is established.
+    class Database
+      attr_reader :db_config
+
+      def self.create!(db_config)
+        ActiveRecord::Base.establish_connection(db_config.merge('database' => 'postgres'))
+        ActiveRecord::Base.connection.create_database(db_config['database'])
+      end
+
+      def self.drop!(db_config)
+        ActiveRecord::Base.establish_connection(db_config.merge('database' => 'postgres'))
+        ActiveRecord::Base.connection.drop_database(db_config['database'])
+      end
+
+      def self.establish_connections(db_config, view_schema_name)
+        Sequent::Support::BaseViewModel.establish_connection(
+          db_config.merge('schema_search_path' => view_schema_name)
+        )
+        ActiveRecord::Base.establish_connection(db_config)
+      end
+
+      def self.disconnect!
+        ActiveRecord::Base.connection_pool.disconnect!
+        Sequent::Support::BaseViewModel.connection_pool.disconnect!
+      end
+
+      def schema_exists?(schema)
+        ActiveRecord::Base.connection.execute(
+          "SELECT schema_name FROM information_schema.schemata WHERE schema_name like '#{schema}'"
+        ).count == 1
+      end
+
+      def create_schema!(schema)
+        sql = "CREATE SCHEMA #{schema}"
+        if user = ActiveRecord::Base.connection_config[:username]
+          sql += " AUTHORIZATION #{user}"
+        end
+        ActiveRecord::Base.connection.execute(sql)
+      end
+
+      def create_schema_if_not_exists!(schema)
+        create_schema!(schema) unless schema_exists?(schema)
+      end
+
+      def drop_schema!(schema)
+        ActiveRecord::Base.connection.execute(
+          "DROP SCHEMA #{schema} CASCADE"
+        )
+      end
+
+      def migrate(migrations_path, verbose: true)
+        ActiveRecord::Migration.verbose = verbose
+        ActiveRecord::Migrator.migrate(migrations_path)
+      end
+    end
+  end
+end

--- a/lib/sequent/support/view_projection.rb
+++ b/lib/sequent/support/view_projection.rb
@@ -1,0 +1,37 @@
+module Sequent
+  module Support
+    class ViewProjection
+      attr_reader :name, :version, :schema_definition
+      def initialize(name, version, schema_definition)
+        @name = name
+        @version = version
+        @schema_definition = schema_definition
+      end
+
+      def build!
+        load schema_definition
+        event_store = Sequent.configuration.event_store
+        event_store.replay_events { Events::ORDERED_BY_ID[event_store] }
+      end
+
+      def schema_name
+        "#{name}_#{version}"
+      end
+    end
+
+    module Events
+      extend ActiveRecord::ConnectionAdapters::Quoting
+
+      ORDERED_BY_ID = lambda do |event_store|
+        event_record_class = event_store.event_record_class
+        snapshot_event_class = event_store.snapshot_event_class
+        event_store.event_record_class.connection.select_all("
+SELECT event_type, event_json
+  FROM #{quote_table_name event_record_class.table_name}
+ WHERE event_type <> #{quote snapshot_event_class}
+ ORDER BY id
+")
+      end
+    end
+  end
+end

--- a/lib/sequent/support/view_projection.rb
+++ b/lib/sequent/support/view_projection.rb
@@ -2,10 +2,10 @@ module Sequent
   module Support
     class ViewProjection
       attr_reader :name, :version, :schema_definition
-      def initialize(name, version, schema_definition)
-        @name = name
-        @version = version
-        @schema_definition = schema_definition
+      def initialize(options)
+        @name = options.fetch(:name)
+        @version = options.fetch(:version)
+        @schema_definition = options.fetch(:definition)
       end
 
       def build!

--- a/lib/sequent/support/view_schema.rb
+++ b/lib/sequent/support/view_schema.rb
@@ -2,17 +2,16 @@ module Sequent
   module Support
     class ViewSchema < ActiveRecord::Schema
       def define(info, &block)
-        view_schema = info[:view_schema]
-        switch_to_schema(view_schema) if view_schema
+        view_projection = info[:view_projection]
+        switch_to_schema(view_projection) if view_projection
         super
       ensure
-        switch_back_to_original_schema if view_schema
+        switch_back_to_original_schema if view_projection
       end
 
-      def switch_to_schema(schema_info)
-        schema = ViewProjection.new(schema_info)
+      def switch_to_schema(view_projection)
         @original_schema_search_path = connection.schema_search_path
-        connection.schema_search_path = schema.schema_name
+        connection.schema_search_path = view_projection.schema_name
       end
 
       def switch_back_to_original_schema

--- a/lib/sequent/support/view_schema.rb
+++ b/lib/sequent/support/view_schema.rb
@@ -1,8 +1,22 @@
 module Sequent
   module Support
     class ViewSchema < ActiveRecord::Schema
-      def connection
-        BaseViewModel.connection
+      def define(info, &block)
+        view_schema = info[:view_schema]
+        switch_to_schema(view_schema) if view_schema
+        super
+      ensure
+        switch_back_to_original_schema if view_schema
+      end
+
+      def switch_to_schema(schema_info)
+        schema = ViewProjection.new(schema_info)
+        @original_schema_search_path = connection.schema_search_path
+        connection.schema_search_path = schema.schema_name
+      end
+
+      def switch_back_to_original_schema
+        connection.schema_search_path = @original_schema_search_path
       end
     end
   end

--- a/lib/sequent/support/view_schema.rb
+++ b/lib/sequent/support/view_schema.rb
@@ -1,0 +1,9 @@
+module Sequent
+  module Support
+    class ViewSchema < ActiveRecord::Schema
+      def connection
+        BaseViewModel.connection
+      end
+    end
+  end
+end

--- a/spec/lib/sequent/support/database_spec.rb
+++ b/spec/lib/sequent/support/database_spec.rb
@@ -60,19 +60,22 @@ describe Sequent::Support::Database do
         }.from(false).to(true)
       end
 
-      it 'skips schema creation if the schema exists' do
+      it 'ignores existing schema' do
         database.create_schema!('eventstore')
         expect { database.create_schema!('eventstore') }.to_not raise_error
       end
     end
 
     describe '#drop_schema!' do
-      before { database.create_schema!('my_app') }
       it 'drops the schema' do
-        database = Sequent::Support::Database.new
+        database.create_schema!('my_app')
         expect { database.drop_schema!('my_app') }.to change {
           database.schema_exists?('my_app')
         }.from(true).to(false)
+      end
+
+      it 'ignores non-existing schema' do
+        expect { database.drop_schema!('my_app') }.to_not raise_error
       end
     end
 

--- a/spec/lib/sequent/support/database_spec.rb
+++ b/spec/lib/sequent/support/database_spec.rb
@@ -59,17 +59,10 @@ describe Sequent::Support::Database do
           database.schema_exists?('eventstore')
         }.from(false).to(true)
       end
-    end
-
-    describe '#create_schema_if_not_exists!' do
-      it 'creates the schema' do
-        expect { database.create_schema_if_not_exists!('eventstore') }.to change {
-          database.schema_exists?('eventstore')
-        }.from(false).to(true)
-      end
 
       it 'skips schema creation if the schema exists' do
-        expect { database.create_schema_if_not_exists!('eventstore') }.to_not raise_error
+        database.create_schema!('eventstore')
+        expect { database.create_schema!('eventstore') }.to_not raise_error
       end
     end
 

--- a/spec/lib/sequent/support/database_spec.rb
+++ b/spec/lib/sequent/support/database_spec.rb
@@ -25,7 +25,7 @@ describe Sequent::Support::Database do
       end
     end
 
-    describe '.establish_connections' do
+    describe '.establish_connection' do
       before { Sequent::Support::Database.create!(db_config) }
       after do
         Sequent::Support::Database.disconnect!
@@ -33,13 +33,8 @@ describe Sequent::Support::Database do
       end
 
       it 'connects the ActiveRecord::Base pool' do
-        Sequent::Support::Database.establish_connections(db_config, 'view_schema_1')
+        Sequent::Support::Database.establish_connection(db_config)
         expect(ActiveRecord::Base.connection).to be_active
-      end
-
-      it 'connects the Sequent::Support::BaseViewModel pool' do
-        Sequent::Support::Database.establish_connections(db_config, 'view_schema_1')
-        expect(Sequent::Support::BaseViewModel.connection).to be_active
       end
     end
   end
@@ -47,7 +42,7 @@ describe Sequent::Support::Database do
   context 'instance methods' do
     before do
       Sequent::Support::Database.create!(db_config)
-      Sequent::Support::Database.establish_connections(db_config, 'view_schema_1')
+      Sequent::Support::Database.establish_connection(db_config)
     end
     after { Sequent::Support::Database.drop!(db_config) }
 

--- a/spec/lib/sequent/support/database_spec.rb
+++ b/spec/lib/sequent/support/database_spec.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+
+require 'sequent/support'
+
+describe Sequent::Support::Database do
+  let(:database_name) { SecureRandom.uuid }
+  let(:db_config) do
+    {'adapter' => 'postgresql',
+     'host' => 'localhost',
+     'database' => database_name}
+  end
+
+  describe 'class methods' do
+    describe '.create' do
+      after { Sequent::Support::Database.drop!(db_config) }
+      it 'creates the database' do
+        expect { Sequent::Support::Database.create!(db_config) }.to change { database_exists? }.from(false).to(true)
+      end
+    end
+
+    describe '.drop' do
+      before { Sequent::Support::Database.create!(db_config) }
+      it 'drop the database' do
+        expect { Sequent::Support::Database.drop!(db_config) }.to change { database_exists? }.from(true).to(false)
+      end
+    end
+
+    describe '.establish_connections' do
+      before { Sequent::Support::Database.create!(db_config) }
+      after do
+        Sequent::Support::Database.disconnect!
+        Sequent::Support::Database.drop!(db_config)
+      end
+
+      it 'connects the ActiveRecord::Base pool' do
+        Sequent::Support::Database.establish_connections(db_config, 'view_schema_1')
+        expect(ActiveRecord::Base.connection).to be_active
+      end
+
+      it 'connects the Sequent::Support::BaseViewModel pool' do
+        Sequent::Support::Database.establish_connections(db_config, 'view_schema_1')
+        expect(Sequent::Support::BaseViewModel.connection).to be_active
+      end
+    end
+  end
+
+  context 'instance methods' do
+    before do
+      Sequent::Support::Database.create!(db_config)
+      Sequent::Support::Database.establish_connections(db_config, 'view_schema_1')
+    end
+    after { Sequent::Support::Database.drop!(db_config) }
+
+    subject(:database) { Sequent::Support::Database.new }
+
+    describe '#create_schema!' do
+      it 'creates the schema' do
+        expect { database.create_schema!('eventstore') }.to change {
+          database.schema_exists?('eventstore')
+        }.from(false).to(true)
+      end
+    end
+
+    describe '#create_schema_if_not_exists!' do
+      it 'creates the schema' do
+        expect { database.create_schema_if_not_exists!('eventstore') }.to change {
+          database.schema_exists?('eventstore')
+        }.from(false).to(true)
+      end
+
+      it 'skips schema creation if the schema exists' do
+        expect { database.create_schema_if_not_exists!('eventstore') }.to_not raise_error
+      end
+    end
+
+    describe '#drop_schema!' do
+      before { database.create_schema!('my_app') }
+      it 'drops the schema' do
+        database = Sequent::Support::Database.new
+        expect { database.drop_schema!('my_app') }.to change {
+          database.schema_exists?('my_app')
+        }.from(true).to(false)
+      end
+    end
+
+    describe '#migrate' do
+      let(:migrations_path) { File.expand_path(database_name, Dir.tmpdir).tap { |dir| Dir.mkdir(dir) } }
+      after { FileUtils.rm_rf(migrations_path) }
+
+      it 'runs pending migrations' do
+        File.open(File.expand_path("1_test_migration.rb", migrations_path), 'w') do |f|
+          f.write <<EOF
+class TestMigration < ActiveRecord::Migration
+  def change
+    create_table "my_table", id: false do |t|
+      t.string "id", null: false
+    end
+  end
+end
+EOF
+          f.flush
+          expect { database.migrate(migrations_path, verbose: false) }.to change {
+            table_exists?('my_table')
+          }.from(false).to(true)
+        end
+      end
+    end
+  end
+
+  def database_exists?
+    results = ActiveRecord::Base.connection.select_all %Q(
+SELECT 1 FROM pg_database
+ WHERE datname = '#{database_name}'
+)
+    results.count == 1
+  end
+
+  def table_exists?(table_name)
+    results = ActiveRecord::Base.connection.select_all %Q(
+SELECT 1 FROM pg_tables
+ WHERE tablename = '#{table_name}'
+)
+    results.count == 1
+  end
+
+  def table_exists?(table_name)
+    results = ActiveRecord::Base.connection.select_all %Q(
+SELECT 1 FROM pg_tables
+ WHERE tablename = '#{table_name}'
+)
+    results.count == 1
+  end
+end


### PR DESCRIPTION
Make Sequent setup a bit less intrusive with some rake tasks to create and maintain the database and the required schemas (for the event store and the view projections).