### PR TITLE
Fix type checking array params in `from_params`

### DIFF
--- a/lib/sequent/core/helpers/array_with_type.rb
+++ b/lib/sequent/core/helpers/array_with_type.rb
@@ -16,6 +16,10 @@ module Sequent
         def to_s
           "Sequent::Core::Helpers::ArrayWithType.new(#{item_type})"
         end
+
+        def candidate?(value)
+          value.is_a?(Array)
+        end
       end
     end
   end

--- a/lib/sequent/core/helpers/param_support.rb
+++ b/lib/sequent/core/helpers/param_support.rb
@@ -29,7 +29,7 @@ module Sequent
             next if value.blank?
             if type.respond_to? :from_params
               value = type.from_params(value)
-            elsif type.is_a? Sequent::Core::Helpers::ArrayWithType
+            elsif value.is_a?(Array)
               value = value.map do |v|
                 if type.item_type.respond_to?(:from_params)
                   type.item_type.from_params(v)

--- a/spec/lib/sequent/core/helpers/association_validator_spec.rb
+++ b/spec/lib/sequent/core/helpers/association_validator_spec.rb
@@ -46,6 +46,11 @@ describe Sequent::Core::Helpers::AssociationValidator do
       expect(object.errors).to_not be_empty
     end
 
+    it "reports a non-array value" do
+      values[:numbers] = "string"
+      subject.validate(object)
+      expect(object.errors).to_not be_empty
+    end
   end
 
   context "validating an array with value objects" do

--- a/spec/lib/sequent/core/helpers/param_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/param_support_spec.rb
@@ -53,6 +53,11 @@ describe Sequent::Core::Helpers::ParamSupport do
         subject = ParamWithArray.new(values: [1, 2])
         expect(subject.to_params(:param_with_array)).to eq ({"param_with_array[values][]" => [1, 2]})
       end
+
+      it "creates an invalid object from invalid params" do
+        params = {'values' => 'string'}
+        expect(ParamWithArray.from_params(params)).to_not be_valid
+      end
     end
 
     context ParamWithValueObjectArray do


### PR DESCRIPTION
Delegate the type checking for array types to the association validator,
while type checking the elements of the array in param support (similar
to any other param).