### PR TITLE
Fix reading 'blank' values from params

### DIFF
--- a/lib/sequent/core/helpers/param_support.rb
+++ b/lib/sequent/core/helpers/param_support.rb
@@ -26,7 +26,7 @@ module Sequent
           self.class.types.each do |attribute, type|
             value = params[attribute]
 
-            next if value.blank?
+            next if value.nil?
             if type.respond_to? :from_params
               value = type.from_params(value)
             elsif value.is_a?(Array)

--- a/spec/lib/sequent/core/helpers/param_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/param_support_spec.rb
@@ -77,5 +77,21 @@ describe Sequent::Core::Helpers::ParamSupport do
         expect(ParamWithNestedArrays.from_params(subject.as_params)).to eq subject
       end
     end
+
+    context Boolean do
+      class ParamWithBool < Sequent::Core::ValueObject
+        attrs value: Boolean
+      end
+
+      it 'assign value with true' do
+        subject = ParamWithBool.from_params('value' => true)
+        expect(subject.value).to eq(true)
+      end
+
+      it 'assign value with false' do
+        subject = ParamWithBool.from_params('value' => false)
+        expect(subject.value).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Values like `false`, `[]`, `''` are `blank` according to ActiveRecord.
Though these represent actual values that you need to deal with. In
params there's a difference between not-present and blank values. Some
of them might be dealt with in the same way (e.g. the params are
invalid), others might be actual values (like false for a Boolean).