### PR TITLE
Change serialising of events to use as_json directly

### DIFF
--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -16,7 +16,17 @@ module Sequent
         self.organization_id = event.organization_id if event.respond_to?(:organization_id)
         self.event_type = event.class.name
         self.created_at = event.created_at
-        self.event_json = Sequent::Core::Oj.dump(event.attributes)
+        self.event_json = self.class.serialize_to_json(event)
+      end
+
+      module ClassMethods
+        def serialize_to_json(event)
+          Sequent::Core::Oj.dump(event)
+        end
+      end
+
+      def self.included(host_class)
+        host_class.extend(ClassMethods)
       end
     end
 

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -122,12 +122,12 @@ EOS
           hash
         end
 
-        def as_json
+        def as_json(opts = {})
           hash = HashWithIndifferentAccess.new
           self.class.types.each do |name, _|
             value = self.instance_variable_get("@#{name}")
             hash[name] = if value.respond_to?(:as_json)
-                           value.as_json
+                           value.as_json(opts)
                          else
                            value
                          end

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -122,6 +122,19 @@ EOS
           hash
         end
 
+        def as_json
+          hash = HashWithIndifferentAccess.new
+          self.class.types.each do |name, _|
+            value = self.instance_variable_get("@#{name}")
+            hash[name] = if value.respond_to?(:as_json)
+                           value.as_json
+                         else
+                           value
+                         end
+          end
+          hash
+        end
+
         def update(changes)
           self.class.new(attributes.merge(changes))
         end
@@ -134,8 +147,8 @@ EOS
               value.validation_errors.each { |k, v| result["#{field[0].to_s}_#{k.to_s}".to_sym] = v }
             elsif field[1].class == ArrayWithType and value.present?
               value
-              .select { |val| val.respond_to?(:validation_errors) }
-              .each_with_index do |val, index|
+                .select { |val| val.respond_to?(:validation_errors) }
+                .each_with_index do |val, index|
                 val.validation_errors.each do |k, v|
                   result["#{field[0].to_s}_#{index}_#{k.to_s}".to_sym] = v
                 end


### PR DESCRIPTION
Previously `event.attributes` was used to serialise events. 
Due to this it was not really possible to change the way an object is
serialised to and from JSON.

By introducing `as_json` explicitly for serialising this option becomes
available.