### PR TITLE
Fix validation of inherited array properties

### DIFF
--- a/lib/sequent/core/helpers/association_validator.rb
+++ b/lib/sequent/core/helpers/association_validator.rb
@@ -34,7 +34,7 @@ module Sequent
             if value && incorrect_type?(value, record, association)
               record.errors[association] = "is not of type #{describe_type(record.class.types[association])}"
             elsif value && value.is_a?(Array)
-              item_type = record.class.type_for(association).item_type
+              item_type = record.class.types.fetch(association).item_type
               record.errors[association] = "is invalid" unless validate_all(value, item_type).all?
             else
               record.errors[association] = "is invalid" if value && value.invalid?

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -33,11 +33,6 @@ module Sequent
             end
           end
 
-          def type_for(name)
-            _, type = types.find { |k, _| k == name }
-            type
-          end
-
           def attrs(args)
             @types ||= {}
             @types.merge!(args)

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -34,7 +34,8 @@ module Sequent
           end
 
           def type_for(name)
-            @types.find { |k, _| k == name }.last
+            _, type = types.find { |k, _| k == name }
+            type
           end
 
           def attrs(args)

--- a/spec/lib/sequent/core/helpers/association_validator_spec.rb
+++ b/spec/lib/sequent/core/helpers/association_validator_spec.rb
@@ -92,6 +92,23 @@ describe Sequent::Core::Helpers::AssociationValidator do
       expect(object.validation_errors[:numbers_0_number]).to_not be_empty
       expect(object.validation_errors[:numbers_2_number]).to_not be_empty
     end
+  end
 
+  context 'inheritance' do
+    let(:options) { {associations: [:numbers]} }
+
+    class ValueObjectWithArray < Sequent::Core::ValueObject
+      attrs numbers: array(Integer)
+
+      validates :numbers, presence: true
+    end
+
+    SubclassWithArray = Class.new(ValueObjectWithArray)
+
+    it 'can handle inherited array properties' do
+      object = SubclassWithArray.new(numbers: (1..5).to_a)
+      subject.validate(object)
+      expect(object.errors).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Include the superclass' types when finding the `type_for` an attribute. 