### PR TITLE
Extend StandardError instead of Exception

### DIFF
--- a/lib/sequent/core/aggregate_repository.rb
+++ b/lib/sequent/core/aggregate_repository.rb
@@ -18,13 +18,13 @@ module Sequent
 
       attr_reader :event_store
 
-      class NonUniqueAggregateId < Exception
+      class NonUniqueAggregateId < StandardError
         def initialize(existing, new)
           super "Duplicate aggregate #{new} with same key as existing #{existing}"
         end
       end
 
-      class AggregateNotFound < Exception
+      class AggregateNotFound < StandardError
         def initialize(id)
           super "Aggregate with id #{id} not found"
         end


### PR DESCRIPTION
Extend 'Exception' for exceptions, unexpected external factors; network
down, out of memory etc.  Extend 'StandardError' to signal application
level errors.

Ruby's 'rescue', without supplying an exception type, will catch
'StandardError' and children.  Exceptions extending 'Exception' will
need to be stated in the rescue statement making it very hard for
frameworks supply 'recue_from' like features.