### PR TITLE
Wrap ActiveRecord::RecordNotUnique with Sequent::Core::EventStore::OptimisticLockingError

### DIFF
--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -174,7 +174,7 @@ SELECT aggregate_id
 
             begin
               event_record_class.create!(values)
-            rescue ActiveRecord::RecordNotUnique => e
+            rescue ActiveRecord::RecordNotUnique
               fail OptimisticLockingError.new(event)
             end
           end


### PR DESCRIPTION
This will impact your app if you are handling `ActiveRecord::RecordNotUnique` originating from the event store.

@bjpbakker @s0meone @erikrozendaal comments?