### PR TITLE
Domain errors

### DIFF
--- a/lib/sequent/core/aggregate_root.rb
+++ b/lib/sequent/core/aggregate_root.rb
@@ -37,6 +37,22 @@ module Sequent
 
       attr_reader :id, :uncommitted_events, :sequence_number, :event_stream
 
+      class DomainError < RuntimeError
+        attr_reader :i18n_parameters
+
+        def initialize(i18n_parameters = {})
+          @i18n_parameters = i18n_parameters
+        end
+
+        def message
+          I18n.t(i18n_key, i18n_parameters)
+        end
+
+        def i18n_key
+          "errors.#{self.class.name}"
+        end
+      end
+
       def self.load_from_history(stream, events)
         first, *rest = events
         if first.is_a? SnapshotEvent

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -28,6 +28,14 @@ module Sequent
         def initialize(event)
           @event = event
         end
+
+        def message
+          I18n.t(i18n_key)
+        end
+
+        def i18n_key
+          "errors.#{self.class.name}"
+        end
       end
 
       class DeserializeEventError < RuntimeError


### PR DESCRIPTION
This can be used in your domain models to raise *domain* exceptions.

Here's an example of how we use this in Freemle:

```
class Invoice < Sequent::Core::AggregateRoot
  class InvoiceAlreadySentError < DomainError; end

  def send
    fail InvoiceAlreadySentError.new(date: @sent_on_date) if @sent_on_date
  end
end
```

Then you can rescue DomainError in your base controller:

```
app.error Sequent::Core::AggregateRoot::DomainError do |e|
  flash[:error] = e.message
  redirect back
end
```

In your translations, you can use `date` as normal:

```
en:
  errors:
    Invoice::InvoiceAlreadySentError: 'This invoice was already sent on %{date}'
```