### PR TITLE
Insert all events per commit in a single statement

### DIFF
--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -74,6 +74,22 @@ describe Sequent::Core::EventStore do
     end
   end
 
+  describe '#commit_events' do
+    it 'fails with OptimisticLockingError when RecordNotUnique' do
+      expect {
+      event_store.commit_events(
+        Sequent::Core::CommandRecord.new,
+        [
+          [
+            Sequent::Core::EventStream.new(aggregate_type: 'MyAggregate', aggregate_id: aggregate_id, snapshot_threshold: 13),
+            [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1), MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)]
+          ]
+        ]
+      )
+      }.to raise_error(Sequent::Core::EventStore::OptimisticLockingError) {|error|expect(error.cause).to be_a(ActiveRecord::RecordNotUnique)}
+    end
+  end
+
   describe '#exists?' do
     it 'gets true for an existing aggregate' do
       event_store.commit_events(


### PR DESCRIPTION
When a command can result in multiple events inserting
each event_record separately can become slow.
By using 

    insert into (..) values (..),(..),(..)

we save roundtrips to the database.

Possible downside is that when an ActiveRecord::RecordNotUnique
is thrown we no longer know which event caused the error.