### PR TITLE
Remove leading zeros from Integer values

### DIFF
--- a/lib/sequent/core/helpers/string_to_value_parsers.rb
+++ b/lib/sequent/core/helpers/string_to_value_parsers.rb
@@ -18,7 +18,8 @@ module Sequent
         }
 
         def self.parse_to_integer(value)
-          Integer(value.gsub(/^[0]+/, '')) unless value.blank?
+          return value if value.is_a?(Integer)
+          Integer(value, 10) unless value.blank?
         end
 
         def self.parse_to_bigdecimal(value)

--- a/lib/sequent/core/helpers/string_to_value_parsers.rb
+++ b/lib/sequent/core/helpers/string_to_value_parsers.rb
@@ -18,7 +18,7 @@ module Sequent
         }
 
         def self.parse_to_integer(value)
-          Integer(value) unless value.blank?
+          Integer(value.gsub(/^[0]+/, '')) unless value.blank?
         end
 
         def self.parse_to_bigdecimal(value)

--- a/spec/lib/sequent/core/command_service_spec.rb
+++ b/spec/lib/sequent/core/command_service_spec.rb
@@ -83,5 +83,12 @@ describe Sequent::Core::CommandService do
                                                                 expect(e.errors[:value]).to eq ['is not a number']
                                                               end
     end
+
+    it "does not removes leading zeros when using hexadecimal values" do
+      command = WithIntegerCommand.new(aggregate_id: "1", value: "0x10")
+      expect { command_service.execute_commands(command) }.to raise_error do |e|
+                                                                expect(e.errors[:value]).to eq ['is not a number']
+                                                              end
+    end
   end
 end

--- a/spec/lib/sequent/core/command_service_spec.rb
+++ b/spec/lib/sequent/core/command_service_spec.rb
@@ -60,8 +60,25 @@ describe Sequent::Core::CommandService do
       command_service.execute_commands(command)
     end
 
+    it 'removes leading zeros if it is valid' do
+      command = WithIntegerCommand.new(aggregate_id: "1", value: "02")
+      expect(foo_handler).to receive(:handles_message?).and_return(true)
+      expect(foo_handler).to receive(:handle_message).with(
+                               WithIntegerCommand.new(aggregate_id: "1", value: 2)
+                             ).and_return(true)
+
+      command_service.execute_commands(command)
+    end
+
     it "does not parse values if the command is invalid" do
       command = WithIntegerCommand.new(value: "A")
+      expect { command_service.execute_commands(command) }.to raise_error do |e|
+                                                                expect(e.errors[:value]).to eq ['is not a number']
+                                                              end
+    end
+
+    it "does not removes leading zeros if command is invalid" do
+      command = WithIntegerCommand.new(aggregate_id: "1", value: "0x")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
                                                                 expect(e.errors[:value]).to eq ['is not a number']
                                                               end


### PR DESCRIPTION
We register validates_numericality_of when using Integer

The value ’09’ is considered numerical but is not a valid Integer 
according to Integer(’09’). So we strip leading zeros since they have
no meaning in Integers.