### PR TITLE
`then_commands` asserts that commands are valid

### DIFF
--- a/lib/sequent/test/event_handler_helpers.rb
+++ b/lib/sequent/test/event_handler_helpers.rb
@@ -61,6 +61,7 @@ module Sequent
         recorded = fake_command_service.recorded_commands
         expect(recorded.map(&:class)).to eq(commands.flatten(1).map(&:class))
         expect(fake_command_service.recorded_commands).to eq(commands.flatten(1))
+        expect(recorded).to all(be_valid)
       end
 
       def self.included(spec)


### PR DESCRIPTION
Executes commands should be valid. Since `then_commands` is a test helper that asserts the attributes of recorded commands (using an internal recorder setup), it should validate that executed commands are valid, too.