### PR TITLE
Register subclasses of Sequent::Core::Command with

### DIFF
--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -36,6 +36,26 @@ module Sequent
       end
     end
 
+    class Commands
+      class << self
+        def commands
+          @commands ||= []
+        end
+
+        def all
+          commands
+        end
+
+        def <<(command)
+          commands << command
+        end
+
+        def find(command_name)
+          commands.find { |c| c.name == command_name }
+        end
+      end
+    end
+
     # Most commonly used command
     # Command can be instantiated just by using:
     #
@@ -54,6 +74,9 @@ module Sequent
         super
       end
 
+      def self.inherited(subclass)
+        Commands << subclass
+      end
     end
 
     class UpdateCommand < Command

--- a/spec/lib/sequent/core/command_spec.rb
+++ b/spec/lib/sequent/core/command_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Sequent::Core::BaseCommand do
-
   it "includes TypeConversion" do
     expect(Sequent::Core::BaseCommand.included_modules).to include(Sequent::Core::Helpers::TypeConversionSupport)
   end
@@ -40,4 +39,13 @@ describe Sequent::Core::BaseCommand do
     end
   end
 
+  context Sequent::Core::Commands do
+    it 'registers subclasses of Sequent::Core::Command' do
+      expect(Sequent::Core::Commands.find('Sequent::Core::UpdateCommand')).to eq Sequent::Core::UpdateCommand
+    end
+
+    it 'does not find any other object' do
+      expect(Sequent::Core::Commands.find('String')).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
Sequent::Core::Commands

This avoids the use of `String#constantize` when you want to find a
command from a string. The syntax is
`Sequent::Core::Commands.find(string)`.