### PR TITLE
Nodowntime replay

### DIFF
--- a/lib/sequent/migrations/migrate_events.rb
+++ b/lib/sequent/migrations/migrate_events.rb
@@ -35,10 +35,11 @@ module Sequent
       #
       def execute_migrations(current_version, new_version, &after_migration_block)
         migrations(current_version, new_version).each do |migration_class|
+          migration = migration_class.new(@env)
           begin
-            migration_class.new(@env).migrate
+            migration.migrate
           ensure
-            yield(upgrade_to_version) if block_given?
+            yield(migration.version) if block_given?
           end
         end
       end

--- a/lib/sequent/migrations/migrate_events.rb
+++ b/lib/sequent/migrations/migrate_events.rb
@@ -34,22 +34,28 @@ module Sequent
       # @param &after_migration_block an optional block (with the current upgrade version as param) to run after the migrations run. E.g. close resources
       #
       def execute_migrations(current_version, new_version, &after_migration_block)
-        if current_version != new_version and current_version > 0
-          ((current_version + 1)..new_version).each do |upgrade_to_version|
-            migration_class = begin
-                                Class.const_get("Database::MigrateToVersion#{upgrade_to_version}")
-                              rescue NameError
-                                nil
-                              end
-            if migration_class
-              begin
-                migration_class.new(@env).migrate
-              ensure
-                yield(upgrade_to_version) if block_given?
-              end
-            end
+        migrations(current_version, new_version).each do |migration_class|
+          begin
+            migration_class.new(@env).migrate
+          ensure
+            yield(upgrade_to_version) if block_given?
           end
         end
+      end
+
+      def migrations(current_version, new_version)
+        return [] if current_version == 0
+        ((current_version + 1)..new_version).map do |upgrade_to_version|
+          begin
+            Class.const_get("Database::MigrateToVersion#{upgrade_to_version}")
+          rescue NameError
+            nil
+          end
+        end.compact
+      end
+
+      def has_migrations?(current_version, new_version)
+        migrations(current_version, new_version).any?
       end
     end
   end

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -265,7 +265,7 @@ describe Sequent::Core::EventStore do
     it "reports progress for each block" do
       progress = 0
       progress_reported_count = 0
-      on_progress = lambda do |n, _|
+      on_progress = lambda do |n, _, _|
         progress = n
         progress_reported_count += 1
       end

--- a/spec/lib/sequent/migrations/migrate_events_spec.rb
+++ b/spec/lib/sequent/migrations/migrate_events_spec.rb
@@ -18,6 +18,10 @@ describe Sequent::Migrations::MigrateEvents do
 
     end
 
+    def version
+      2
+    end
+
     def migrate
       @@called = true
     end
@@ -40,6 +44,11 @@ describe Sequent::Migrations::MigrateEvents do
     def migrate
       @@called = true
     end
+
+    def version
+      3
+    end
+
   end
 
   class Database::MigrateToVersion4
@@ -49,6 +58,11 @@ describe Sequent::Migrations::MigrateEvents do
     def migrate
       raise 'for spec'
     end
+
+    def version
+      4
+    end
+
   end
 
   after :each do


### PR DESCRIPTION
Enable projects to replay events without downtime. The strategy is as follows:

1) Create new view schema
2) Replay all events
3) When done put the app in maintenance mode (this is only for a short time)
4) Replay events not yet replayed
5) Switch view schema
6) Restart your app

To keep track of events not yet replayed the `on_progress` block is passed in the ids of the
events replayed. The app that is deployed needs to keep track of these ids so in step 4 you can select all events `where id not in (replayed_ids)`.