### PR TITLE
Always require a new transaction.

### DIFF
--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -4,7 +4,7 @@ module Sequent
 
       class ActiveRecordTransactionProvider
         def transactional
-          ActiveRecord::Base.transaction do
+          ActiveRecord::Base.transaction(requires_new: true) do
             yield
           end
         end


### PR DESCRIPTION
Read:
http://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html

Without this change, there is a potential bug:

```ruby
ActiveRecord::Base.transaction do
  Sequent.configuration.command_service.execute_commands command
end

on Command do
  do.some.things
  fail ActiveRecord::Rollback
end
```

In this example, you might be surprised to find that `do.some.things`
does not get rolled back! This is because AR doesn't automatically make
a "savepoint" for us when we call `.transaction` in a nested manner. In
order to enable this behaviour, we have to call `.transaction` like
this: `.transaction(requires_new: true)`.