### PR TITLE
Play all events per-event handler.

### DIFF
--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -178,8 +178,8 @@ SELECT aggregate_id
 
       def publish_events(events, event_handlers)
         return if configuration.disable_event_handlers
-        events.each do |event|
-          event_handlers.each do |handler|
+        event_handlers.each do |handler|
+          events.each do |event|
             begin
               handler.handle_message event
             rescue


### PR DESCRIPTION
Instead of replaying one event to all event handlers, and then moving on
to the next event. This caused a bug in workflows:

Say you append a number of events to an aggregate. The first of these
events triggers a workflow, which appends some extra events. These extra
events will be sent *first* to the event handlers, out of order.

To get the correct order of events being applied, it's still important to
always have workflows lower in the event_handlers list than projectors.