### PR TITLE
Feature/load multiple aggregates

### DIFF
--- a/lib/sequent/core/aggregate_repository.rb
+++ b/lib/sequent/core/aggregate_repository.rb
@@ -60,12 +60,12 @@ module Sequent
           stream, events = @event_store.load_events(aggregate_id)
           raise AggregateNotFound.new(aggregate_id) unless stream
           aggregate_class = Class.const_get(stream.aggregate_type)
-          aggregates[aggregate_id] = aggregate_class.load_from_history(stream, events)
+          aggregate_class.load_from_history(stream, events)
         end
 
-        raise TypeError, "#{result.class} is not a #{clazz}" if result && clazz && !(result.class <= clazz)
+        raise TypeError, "#{result.class} is not a #{clazz}" if clazz && result && !(result.class <= clazz)
+        aggregates[aggregate_id] = result
 
-        result
       end
 
       ##

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -79,6 +79,29 @@ SELECT event_type, event_json
         [stream.event_stream, events]
       end
 
+      def load_events_for_aggregates(aggregate_ids)
+        return [] if aggregate_ids.none?
+
+        streams = stream_record_class.where(aggregate_id: aggregate_ids)
+
+        events = event_record_class.connection.select_all(%Q{
+SELECT event_type, event_json
+  FROM #{quote_table_name event_record_class.table_name}
+WHERE aggregate_id in (#{aggregate_ids.map{ |aggregate_id| quote(aggregate_id)}.join(",")})
+  AND sequence_number >= COALESCE((SELECT MAX(sequence_number)
+                                      FROM #{quote_table_name event_record_class.table_name}
+                                     WHERE event_type = #{quote snapshot_event_class.name}
+                                       AND aggregate_id in (#{aggregate_ids.map{ |aggregate_id| quote(aggregate_id)}.join(",")})), 0)
+  ORDER BY sequence_number ASC, (CASE event_type WHEN #{quote snapshot_event_class.name} THEN 0 ELSE 1 END) ASC
+}).map! do |event_hash|
+          deserialize_event(event_hash)
+        end
+
+        events
+          .group_by { |event| event.aggregate_id }
+          .map { |aggregate_id, _events| [streams.find { |stream_record| stream_record.aggregate_id == aggregate_id }.event_stream, _events] }
+      end
+
       def stream_exists?(aggregate_id)
         stream_record_class.exists?(aggregate_id: aggregate_id)
       end

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -62,21 +62,7 @@ module Sequent
       # Returns all events for the aggregate ordered by sequence_number
       #
       def load_events(aggregate_id)
-        stream = stream_record_class.where(aggregate_id: aggregate_id).first
-        return nil unless stream
-        events = event_record_class.connection.select_all(%Q{
-SELECT event_type, event_json
-  FROM #{quote_table_name event_record_class.table_name}
- WHERE aggregate_id = #{quote aggregate_id}
-   AND sequence_number >= COALESCE((SELECT MAX(sequence_number)
-                                      FROM #{quote_table_name event_record_class.table_name}
-                                     WHERE event_type = #{quote snapshot_event_class.name}
-                                       AND aggregate_id = #{quote aggregate_id}), 0)
- ORDER BY sequence_number ASC, (CASE event_type WHEN #{quote snapshot_event_class.name} THEN 0 ELSE 1 END) ASC
-}).map! do |event_hash|
-          deserialize_event(event_hash)
-        end
-        [stream.event_stream, events]
+        load_events_for_aggregates([aggregate_id])[0]
       end
 
       def load_events_for_aggregates(aggregate_ids)

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -49,6 +49,10 @@ module Sequent
           [event_stream, deserialize_events(@all_events[aggregate_id])]
         end
 
+        def load_events_for_aggregates(aggregate_ids)
+          aggregate_ids.map { |id| load_events(id) }
+        end
+
         def find_event_stream(aggregate_id)
           @event_streams[aggregate_id]
         end

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'activemodel', '~> 4.0'
   s.add_dependency              'pg', '~> 0.18'
   s.add_dependency              'postgresql_cursor', '~> 0.6'
-  s.add_dependency              'oj', '~> 2.10'
+  s.add_dependency              'oj', '~> 2.17.5'
   s.add_dependency              'thread_safe', '~> 0.3.5'
   s.add_development_dependency  'rspec', '~> 3.2'
   s.add_development_dependency  'rspec-mocks', '~> 3.2'


### PR DESCRIPTION
Instead of `ids.map {|id|repository.load_aggregate(id)}` you can do `repository.load_aggregate(ids)`.
