### PR TITLE
Add `.handles_message?` method

### DIFF
--- a/lib/sequent/core/aggregate_snapshotter.rb
+++ b/lib/sequent/core/aggregate_snapshotter.rb
@@ -6,7 +6,7 @@ module Sequent
 
     class AggregateSnapshotter < BaseCommandHandler
 
-      def handles_message?(message)
+      def self.handles_message?(message)
         message.is_a? SnapshotCommand
       end
 

--- a/lib/sequent/core/base_command_handler.rb
+++ b/lib/sequent/core/base_command_handler.rb
@@ -26,16 +26,12 @@ module Sequent
         @repository = repository
       end
 
-      def handles_message?(command)
-        self.class.message_mapping.keys.include? command.class
-      end
-
       protected
+
       def do_with_aggregate(command, clazz, aggregate_id = nil)
         aggregate = @repository.load_aggregate(aggregate_id.nil? ? command.aggregate_id : aggregate_id, clazz)
         yield aggregate if block_given?
       end
-
     end
   end
 end

--- a/lib/sequent/core/command_service.rb
+++ b/lib/sequent/core/command_service.rb
@@ -41,7 +41,7 @@ module Sequent
 
               raise CommandNotValid.new(command) unless command.valid?
               parsed_command = command.parse_attrs_to_correct_types
-              command_handlers.select { |h| h.handles_message?(parsed_command) }.each { |h| h.handle_message parsed_command }
+              command_handlers.select { |h| h.class.handles_message?(parsed_command) }.each { |h| h.handle_message parsed_command }
               repository.commit(parsed_command)
             end
           end

--- a/lib/sequent/core/helpers/self_applier.rb
+++ b/lib/sequent/core/helpers/self_applier.rb
@@ -34,6 +34,10 @@ module Sequent
           host_class.extend(ClassMethods)
         end
 
+        def handles_message?(message)
+          self.class.handles_message?(message)
+        end
+
         def handle_message(message)
           handler = self.class.message_mapping[message.class]
           self.instance_exec(message, &handler) if handler

--- a/lib/sequent/core/helpers/self_applier.rb
+++ b/lib/sequent/core/helpers/self_applier.rb
@@ -34,10 +34,6 @@ module Sequent
           host_class.extend(ClassMethods)
         end
 
-        def handles_message?(message)
-          self.class.handles_message?(message)
-        end
-
         def handle_message(message)
           handler = self.class.message_mapping[message.class]
           self.instance_exec(message, &handler) if handler

--- a/lib/sequent/core/helpers/self_applier.rb
+++ b/lib/sequent/core/helpers/self_applier.rb
@@ -17,13 +17,16 @@ module Sequent
       module SelfApplier
 
         module ClassMethods
-
           def on(*message_classes, &block)
             message_classes.each { |message_class| message_mapping[message_class] = block }
           end
 
           def message_mapping
             @message_mapping ||= {}
+          end
+
+          def handles_message?(message)
+            message_mapping.keys.include? message.class
           end
         end
 
@@ -35,9 +38,7 @@ module Sequent
           handler = self.class.message_mapping[message.class]
           self.instance_exec(message, &handler) if handler
         end
-
       end
-
     end
   end
 end

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -127,7 +127,7 @@ module Sequent
 
       def when_command command
         raise "@command_handler is mandatory when using the #{self.class}" unless @command_handler
-        raise "Command handler #{@command_handler} cannot handle command #{command}, please configure the command type (forgot an include in the command class?)" unless @command_handler.handles_message?(command)
+        raise "Command handler #{@command_handler} cannot handle command #{command}, please configure the command type (forgot an include in the command class?)" unless @command_handler.class.handles_message?(command)
         @command_handler.handle_message(command)
         @repository.commit(command)
         @repository.clear

--- a/spec/lib/sequent/core/command_service_spec.rb
+++ b/spec/lib/sequent/core/command_service_spec.rb
@@ -9,30 +9,60 @@ class DummyBaseCommand < Sequent::Core::BaseCommand
   validates_presence_of :mandatory_string
 end
 
+class NotHandledCommand < Sequent::Core::Command; end
+
+class WithIntegerCommand < Sequent::Core::BaseCommand
+  attrs value: Integer
+end
+
+class TestCommandHandler < Sequent::Core::BaseCommandHandler
+  def initialize(*args)
+    reset
+    super(*args)
+  end
+
+  def reset
+    @@called = nil
+  end
+
+  def called
+    @@called
+  end
+
+  on DummyCommand do
+    @@called = 'DummyCommand'
+  end
+
+  on DummyBaseCommand do
+    @@called = 'DummyBaseCommand'
+  end
+
+  on WithIntegerCommand do |command|
+    @@called = command
+  end
+end
+
 describe Sequent::Core::CommandService do
 
   let(:event_store) { double }
-  let(:foo_handler) { double }
-  let(:command) { DummyCommand.new(aggregate_id: "1") }
+
+  let(:command_handler) { TestCommandHandler.new }
 
   let(:command_service) do
     Sequent.configure do |config|
-      config.command_handlers = [foo_handler]
+      config.command_handlers = [command_handler]
     end
     Sequent.configuration.command_service
   end
 
-  it "does not call a command handler when it does not handle a certain command" do
-    expect(foo_handler).to receive(:handles_message?).and_return(false)
-
-    command_service.execute_commands(command)
+  it "does not break when it does not handle a certain command" do
+    command_service.execute_commands(NotHandledCommand.new(aggregate_id: "1"))
+    expect(command_handler.called).to be_nil
   end
 
   it "calls a command handler when it does handle a certain command" do
-    expect(foo_handler).to receive(:handles_message?).and_return(true)
-    expect(foo_handler).to receive(:handle_message).with(command).and_return(true)
-
-    command_service.execute_commands(command)
+    command_service.execute_commands(DummyCommand.new(aggregate_id: "1"))
+    expect(command_handler.called).to eq "DummyCommand"
   end
 
   it "raises a CommandNotValid for invalid commands" do
@@ -45,50 +75,35 @@ describe Sequent::Core::CommandService do
   end
 
   context "command value parsing" do
-    class WithIntegerCommand < Sequent::Core::BaseCommand
-      attrs value: Integer
-    end
-
     it "parses the values in the command if it is valid" do
-      command = WithIntegerCommand.new(aggregate_id: "1", value: "2")
-
-      expect(foo_handler).to receive(:handles_message?).and_return(true)
-      expect(foo_handler).to receive(:handle_message).with(
-                               WithIntegerCommand.new(aggregate_id: "1", value: 2)
-                             ).and_return(true)
-
-      command_service.execute_commands(command)
+      command_service.execute_commands(WithIntegerCommand.new(aggregate_id: "1", value: "2"))
+      expect(command_handler.called.value).to eq 2
     end
 
     it 'removes leading zeros if it is valid' do
-      command = WithIntegerCommand.new(aggregate_id: "1", value: "02")
-      expect(foo_handler).to receive(:handles_message?).and_return(true)
-      expect(foo_handler).to receive(:handle_message).with(
-                               WithIntegerCommand.new(aggregate_id: "1", value: 2)
-                             ).and_return(true)
-
-      command_service.execute_commands(command)
+      command_service.execute_commands(WithIntegerCommand.new(aggregate_id: "1", value: "02"))
+      expect(command_handler.called.value).to eq 2
     end
 
     it "does not parse values if the command is invalid" do
       command = WithIntegerCommand.new(value: "A")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
-                                                                expect(e.errors[:value]).to eq ['is not a number']
-                                                              end
+        expect(e.errors[:value]).to eq ['is not a number']
+      end
     end
 
     it "does not removes leading zeros if command is invalid" do
       command = WithIntegerCommand.new(aggregate_id: "1", value: "0x")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
-                                                                expect(e.errors[:value]).to eq ['is not a number']
-                                                              end
+        expect(e.errors[:value]).to eq ['is not a number']
+      end
     end
 
     it "does not removes leading zeros when using hexadecimal values" do
       command = WithIntegerCommand.new(aggregate_id: "1", value: "0x10")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
-                                                                expect(e.errors[:value]).to eq ['is not a number']
-                                                              end
+        expect(e.errors[:value]).to eq ['is not a number']
+      end
     end
   end
 end


### PR DESCRIPTION
I have added this because it's a convenient interface that I can
overwrite when my own implementation of `.handle_message` differs.

It's similar to `.method_missing` and `.respond_to?`.