### PR TITLE
update oj to ~> 3.3.9, and use :rails mode to mimic the ActiveSupport…

### DIFF
--- a/lib/sequent/core/sequent_oj.rb
+++ b/lib/sequent/core/sequent_oj.rb
@@ -6,7 +6,7 @@ module Sequent
     class Oj
       ::Oj.default_options = {
         bigdecimal_as_decimal: false,
-        mode: :compat,
+        mode: :rails,
       }
 
       def self.strict_load(json)

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'activemodel', active_star_version
   s.add_dependency              'pg', '~> 0.18'
   s.add_dependency              'postgresql_cursor', '~> 0.6'
-  s.add_dependency              'oj', '~> 2.17.5'
+  s.add_dependency              'oj', '~> 3.3.9'
   s.add_dependency              'thread_safe', '~> 0.3.5'
   s.add_development_dependency  'rspec', '~> 3.2'
   s.add_development_dependency  'rspec-mocks', '~> 3.2'


### PR DESCRIPTION
… version 5 encoder

more details at https://github.com/ohler55/oj/blob/master/pages/Rails.md

when i try to integrate Oj 3.x with Rails 5.1.x, bundler could not find compatible versions for Oj since sequent is using ~> 2.17.5.

Oj 3.x has better Rails 5.x compatibility. Since https://github.com/zilverline/sequent/pull/88 supports rails 5.1, I think it's better to upgrade Oj to 3.x as well.
