### PR TITLE
Fix sequent generators

### DIFF
--- a/bin/sequent
+++ b/bin/sequent
@@ -2,8 +2,10 @@
 require_relative '../lib/sequent/generator'
 
 command = ARGV[0].to_s.strip
-args = ARGV[1..-1].map(&:to_s).map(&:strip)
 abort('Please specify a command. i.e. `sequent new myapp`') if command.empty?
+abort('Please specify a command. i.e. `sequent new myapp`') if ARGV[1..-1].empty?
+
+args = ARGV[1..-1].map(&:to_s).map(&:strip)
 
 def new_project(args)
   _args = args.dup

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'oj', '~> 3.3.9'
   s.add_dependency              'thread_safe', '~> 0.3.5'
   s.add_dependency              'parallel', '~> 1.12.1'
+  s.add_dependency              'parser', '~> 2.5.1.0'
   s.add_development_dependency  'rspec', '~> 3.2'
   s.add_development_dependency  'timecop', '~> 0.9'
   s.add_development_dependency  'rspec-mocks', '~> 3.2'
@@ -36,5 +37,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency  'rake', '~> 10.4'
   s.add_development_dependency  'pry', '~> 0.10'
   s.add_development_dependency  'simplecov', '~> 0.14.1'
-  s.add_development_dependency  'parser', '~> 2.5.1.0'
 end


### PR DESCRIPTION
Add ‘parser’ as dependency otherwise the generator does not work.
First check arguments are present before further parsing of generator commands.

Fixes https://github.com/zilverline/sequent/issues/140