### PR TITLE
Add apply if changed

### DIFF
--- a/lib/sequent/core/aggregate_root.rb
+++ b/lib/sequent/core/aggregate_root.rb
@@ -102,6 +102,30 @@ module Sequent
         apply_event(event)
         @uncommitted_events << event
       end
+
+      # Only apply the event if one of the attributes of the event changed
+      #
+      # on NameSet do |event|
+      #   @first_name = event.first_name
+      #   @last_name = event.last_name
+      # end
+      #
+      # # The event is applied
+      # apply_if_changed NameSet, first_name: 'Ben', last_name: 'Vonk'
+      #
+      # # This event is not applied
+      # apply_if_changed NameSet, first_name: 'Ben', last_name: 'Vonk'
+      #
+      def apply_if_changed(event_class, args = {})
+        if args.empty?
+          apply event_class
+        elsif self.class
+             .event_attribute_keys(event_class)
+             .any? { |k| instance_variable_get(:"@#{k.to_s}") != args[k.to_sym] }
+          apply event_class, args
+        end
+      end
+
     end
   end
 end

--- a/lib/sequent/core/aggregate_root.rb
+++ b/lib/sequent/core/aggregate_root.rb
@@ -1,9 +1,11 @@
 require 'base64'
 require_relative 'helpers/message_handler'
+require_relative 'helpers/autoset_attributes'
 require_relative 'stream_record'
 
 module Sequent
   module Core
+
     module SnapshotConfiguration
       module ClassMethods
         ##
@@ -33,6 +35,7 @@ module Sequent
     #
     class AggregateRoot
       include Helpers::MessageHandler
+      include Helpers::AutosetAttributes
       include SnapshotConfiguration
 
       attr_reader :id, :uncommitted_events, :sequence_number, :event_stream

--- a/lib/sequent/core/helpers/autoset_attributes.rb
+++ b/lib/sequent/core/helpers/autoset_attributes.rb
@@ -1,0 +1,56 @@
+module Sequent
+  module Core
+    module Helpers
+      ##
+      # In some cases you just want to store the events as instance variables
+      # on the AggregateRoot. In that case you can use the following code:
+      #
+      # class LineItemsSet < Sequent::Event
+      #   attrs line_items: array(LineItem)
+      # end
+      #
+      # class Invoice < Sequent::AggregateRoot
+      #   self.autoset_attributes_for_events LineItemsSet
+      # end
+      #
+      # This will automatically create the following block
+      #
+      # on LineItemSet do |event|
+      #   @line_items = event.line_items
+      # end
+      #
+      # The +autoset_attributes_for_events+ will set all the defined +attrs+
+      # as instance variable, except for the ones defined in +autoset_ignore_attributes+.
+      #
+      module AutosetAttributes
+        module ClassMethods
+
+          @@autoset_ignore_attributes = %w{aggregate_id sequence_number created_at}
+
+          def set_autoset_ignore_attributes(attribute_names)
+            @@autoset_ignore_attributes = attribute_names
+          end
+
+          def event_attribute_keys(event_class)
+            event_class.types.keys.reject { |k| @@autoset_ignore_attributes.include?(k.to_s) }
+          end
+
+          def autoset_attributes_for_events(*event_classes)
+            event_classes.each do |event_class|
+              on event_class do |event|
+                self.class.event_attribute_keys(event_class).each do |attribute_name|
+                  instance_variable_set(:"@#{attribute_name.to_s}", event.send(attribute_name.to_sym))
+                end
+              end
+            end
+          end
+        end
+
+        def self.included(host_class)
+          host_class.extend(ClassMethods)
+        end
+      end
+    end
+  end
+end
+

--- a/spec/lib/sequent/core/aggregate_root_spec.rb
+++ b/spec/lib/sequent/core/aggregate_root_spec.rb
@@ -89,4 +89,29 @@ describe Sequent::Core::AggregateRoot do
       expect(restored.event_count).to eq 1
     end
   end
+
+  context 'apply_if_changed' do
+    require_relative 'fixtures'
+
+    it 'only applies the event if one of the attributes changes' do
+      subject = PersonAggregate.new('1')
+      subject.clear_events
+
+      subject.set_name_if_changed('kim', 'bos')
+      subject.set_name_if_changed('kim', 'bos')
+      expect(subject.uncommitted_events).to have(1).item
+
+      subject = PersonAggregate.new('1')
+      subject.clear_events
+      subject.set_name_if_changed('kim', 'bos')
+      subject.set_name_if_changed('kim2', 'bos')
+      expect(subject.uncommitted_events).to have(2).items
+
+      subject = PersonAggregate.new('1')
+      subject.clear_events
+      subject.set_name_if_changed('kim', 'bos')
+      subject.set_name_if_changed('kim', 'bos2')
+      expect(subject.uncommitted_events).to have(2).items
+    end
+  end
 end

--- a/spec/lib/sequent/core/aggregate_root_spec.rb
+++ b/spec/lib/sequent/core/aggregate_root_spec.rb
@@ -90,6 +90,22 @@ describe Sequent::Core::AggregateRoot do
     end
   end
 
+  context 'AutosetAttributes' do
+    require_relative 'fixtures'
+
+    it 'autosets attributes' do
+      subject = PersonAggregate.new('1')
+
+      subject.set_name('kim', 'bos')
+      expect(subject.first_name).to eq 'kim'
+      expect(subject.last_name).to eq 'bos'
+
+      subject.set_name('bos', 'kim')
+      expect(subject.first_name).to eq 'bos'
+      expect(subject.last_name).to eq 'kim'
+    end
+  end
+
   context 'apply_if_changed' do
     require_relative 'fixtures'
 

--- a/spec/lib/sequent/core/fixtures.rb
+++ b/spec/lib/sequent/core/fixtures.rb
@@ -1,0 +1,26 @@
+class NameSet < Sequent::Event
+  attrs first_name: String, last_name: String
+end
+
+class PersonAggregate < Sequent::Core::AggregateRoot
+  attr_reader :first_name, :last_name
+
+  self.autoset_attributes_for_events(NameSet)
+
+  def initialize(id)
+    super(id)
+    apply TestEvent, field: "value"
+  end
+
+  def set_name(first_name, last_name)
+    apply NameSet, first_name: first_name, last_name: last_name
+  end
+
+  def set_name_if_changed(first_name, last_name)
+    apply_if_changed NameSet, first_name: first_name, last_name: last_name
+  end
+
+  private
+  on TestEvent do
+  end
+end


### PR DESCRIPTION
This PR adds two features:

1. `apply_if_changed`

In some cases you only want to apply an event if the relevant state changed. For instance if you call

```ruby
person.set_name('ben')
person.set_name('ben')
```

you may want to only apply `set_name` once. For this scenario you had to implement this yourself like:

```ruby
class Person < Sequent::AggregateRoot
  def set_name(name)
    apply NameSet, name: name unless @name == name
  end

  on NameSet do |event|
    @name = event.name
  end
end
```

With `apply_if_changed` you can use: `apply_if_changed, NameSet, name: name`

2. Add `autoset_attributes_for_events`

This will register event handlers for all relevant events for which you just want to capture the defined `attrs` in the AggregateRoots state.

With this we can re-write the above example as:

```ruby
class Person < Sequent::AggregateRoot
  self.autoset_attributes_for_events = [NameSet]

  def set_name(name)
    apply_if_changed NameSet, name: name
  end
end
```