### PR TITLE
Allow activerecord 5.2.x versions

### DIFF
--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'https://github.com/zilverline/sequent'
   s.license       = 'MIT'
 
-  active_star_version = ENV['ACTIVE_STAR_VERSION'] || ['>= 5.0', '<= 5.2']
+  active_star_version = ENV['ACTIVE_STAR_VERSION'] || ['>= 5.0', '< 5.3']
 
   s.add_dependency              'activerecord', active_star_version
   s.add_dependency              'activemodel', active_star_version


### PR DESCRIPTION
Fixes #151 