### PR TITLE
Add Sequent::Secret as a Type

### DIFF
--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -16,6 +16,7 @@ module Sequent
               Sequent::Core::Helpers::EqualSupport,
               Sequent::Core::Helpers::ParamSupport,
               Sequent::Core::Helpers::Mergable
+      include ActiveModel::Validations::Callbacks
       include Sequent::Core::Helpers::TypeConversionSupport
 
       attrs created_at: DateTime

--- a/lib/sequent/core/helpers/default_validators.rb
+++ b/lib/sequent/core/helpers/default_validators.rb
@@ -2,6 +2,7 @@ require_relative 'string_validator'
 require_relative 'boolean_validator'
 require_relative 'date_time_validator'
 require_relative 'date_validator'
+require_relative 'secret'
 
 module Sequent
   module Core
@@ -22,6 +23,16 @@ module Sequent
           end,
           String => -> (klass, field) do
             klass.validates field, "sequent::Core::Helpers::String" => true
+          end,
+          Sequent::Core::Helpers::Secret => -> (klass, field) do
+            klass.after_validation do |object|
+              if object.errors&.any?
+                object.send("#{field}=", nil)
+              else
+                raw_value = object.send(field)
+                object.send("#{field}=", Sequent::Secret.new(raw_value)) if raw_value
+              end
+            end
           end
         }
 

--- a/lib/sequent/core/helpers/secret.rb
+++ b/lib/sequent/core/helpers/secret.rb
@@ -1,0 +1,124 @@
+require 'bcrypt'
+
+module Sequent
+  module Core
+    module Helpers
+
+      #
+      # You can use this in Commands to handle for instance passwords
+      # safely. It uses BCrypt to encrypt the Secret.
+      #
+      # Attributes that are of type Secret are encrypted **after** successful validation in the CommandService
+      # automatically. So there is no need to do this yourself, Sequent will take care of this for you.
+      # As a result the CommandHandlers will receive the encrypted values.
+      #
+      # Since this is meant to be used in +Command+s based on input you can
+      # put in +String+s and +Secret+s.
+      #
+      # Example usage:
+      #
+      #   class CreateUser < Sequent::Command
+      #     attrs email: String, password: Sequent::Secret
+      #   end
+      #
+      #   command = CreateUser.new(
+      #     aggregate_id: Sequent.new_uuid,
+      #     email: 'ben@sequent.io',
+      #     password: 'secret',
+      #   )
+      #
+      #   puts command.password
+      #   => secret
+      #
+      #   command.valid?
+      #   => true
+      #
+      #   command = command.parse_attrs_to_correct_types
+      #   puts command.password
+      #   => SAasdf239as$%^@#%dasfgasasdf (or something similar :-))
+      #
+      # When command validation fails attributes of type Sequent::Secret are cleared.
+      #
+      #   command.valid?
+      #   => false
+      #
+      #   puts command.password
+      #   => ''
+      #
+      # There is no real need to use this type in Events since there we are
+      # only interested in the encrypted String at that point.
+      #
+      # Besides the Sequent::Secret type there are also some helper methods available to
+      # assist in verifying secrets.
+      #
+      # See +encrypt_secret+
+      # See +re_encrypt_secret+
+      # See +verify_secret+
+      class Secret
+
+        class << self
+          def deserialize_from_json(value)
+            new(value)
+          end
+
+          ##
+          # Creates a hash for the given clear text password.
+          #
+          def encrypt_secret(clear_text_secret)
+            fail ArgumentError.new('clear_text_secret can not be blank') if clear_text_secret.blank?
+            BCrypt::Password.create(clear_text_secret)
+          end
+
+          ##
+          # Creates a hash for the given clear text secret using the given hashed secret as a salt
+          # (essentially re-creating the secret hash).
+          #
+          def re_encrypt_secret(clear_text_secret, hashed_secret)
+            fail ArgumentError.new('clear_text_secret can not be blank') if clear_text_secret.blank?
+            fail ArgumentError.new('hashed_secret can not be blank') if hashed_secret.blank?
+
+            BCrypt::Engine.hash_secret(clear_text_secret, hashed_secret)
+          end
+
+          ##
+          # Verifies that the hashed and clear text secret are equal.
+          #
+          def verify_secret(hashed_secret, clear_text_secret)
+            return false if (hashed_secret.blank? || clear_text_secret.blank?)
+
+            BCrypt::Password.new(hashed_secret) == clear_text_secret
+          end
+        end
+
+        attr_reader :value
+
+        def initialize(value)
+          fail ArgumentError.new('value can not be blank') if value.blank?
+          if value.is_a?(Secret)
+            @value = value.value
+          else
+            @value = value
+          end
+        end
+
+        def encrypt
+          @value = self.class.encrypt_secret(@value)
+          self
+        end
+
+        def verify_secret(clear_text_secret)
+          self.class.verify_secret(@value, clear_text_secret)
+        end
+
+        def ==(other)
+          return false unless other&.class == Secret
+
+          other.value == @value
+        end
+      end
+    end
+  end
+
+  # Shortcut
+  Secret = Core::Helpers::Secret
+end

--- a/lib/sequent/core/helpers/string_to_value_parsers.rb
+++ b/lib/sequent/core/helpers/string_to_value_parsers.rb
@@ -14,7 +14,8 @@ module Sequent
           ::Boolean => ->(value) { parse_to_bool(value) },
           ::Date => ->(value) { parse_to_date(value) },
           ::DateTime => ->(value) { parse_to_date_time(value) },
-          ::Sequent::Core::Helpers::ArrayWithType => ->(values, type_in_array) { parse_array(values, type_in_array) }
+          ::Sequent::Core::Helpers::ArrayWithType => ->(values, type_in_array) { parse_array(values, type_in_array) },
+          ::Sequent::Core::Helpers::Secret => ->(value) { Sequent::Core::Helpers::Secret.new(value).encrypt },
         }
 
         def self.parse_to_integer(value)

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'oj', '~> 3.3.9'
   s.add_dependency              'thread_safe', '~> 0.3.5'
   s.add_dependency              'parallel', '~> 1.12.1'
+  s.add_dependency              'bcrypt', '~> 3.1'
   s.add_dependency              'parser', '~> 2.5.1.0'
   s.add_development_dependency  'rspec', '~> 3.2'
   s.add_development_dependency  'timecop', '~> 0.9'

--- a/spec/lib/sequent/core/command_service_spec.rb
+++ b/spec/lib/sequent/core/command_service_spec.rb
@@ -1,21 +1,23 @@
 require 'spec_helper'
 
-class DummyCommand < Sequent::Core::Command
+class TestCommandHandler < Sequent::CommandHandler
+  class DummyCommand < Sequent::Core::Command; end
 
-end
+  class DummyBaseCommand < Sequent::Core::BaseCommand
+    attrs mandatory_string: String
+    validates_presence_of :mandatory_string
+  end
 
-class DummyBaseCommand < Sequent::Core::BaseCommand
-  attrs mandatory_string: String
-  validates_presence_of :mandatory_string
-end
+  class NotHandledCommand < Sequent::Core::Command; end
 
-class NotHandledCommand < Sequent::Core::Command; end
+  class WithIntegerCommand < Sequent::Core::BaseCommand
+    attrs value: Integer
+  end
 
-class WithIntegerCommand < Sequent::Core::BaseCommand
-  attrs value: Integer
-end
+  class CommandWithSecret < Sequent::Core::BaseCommand
+    attrs password: Sequent::Secret
+  end
 
-class TestCommandHandler < Sequent::Core::BaseCommandHandler
   def initialize(*args)
     reset
     super(*args)
@@ -23,10 +25,15 @@ class TestCommandHandler < Sequent::Core::BaseCommandHandler
 
   def reset
     @@called = nil
+    @@password = nil
   end
 
   def called
     @@called
+  end
+
+  def password
+    @@password
   end
 
   on DummyCommand do
@@ -39,6 +46,10 @@ class TestCommandHandler < Sequent::Core::BaseCommandHandler
 
   on WithIntegerCommand do |command|
     @@called = command
+  end
+
+  on CommandWithSecret do |command|
+    @@password = command.password
   end
 end
 
@@ -56,51 +67,58 @@ describe Sequent::Core::CommandService do
   end
 
   it "does not break when it does not handle a certain command" do
-    command_service.execute_commands(NotHandledCommand.new(aggregate_id: "1"))
+    command_service.execute_commands(TestCommandHandler::NotHandledCommand.new(aggregate_id: "1"))
     expect(command_handler.called).to be_nil
   end
 
   it "calls a command handler when it does handle a certain command" do
-    command_service.execute_commands(DummyCommand.new(aggregate_id: "1"))
+    command_service.execute_commands(TestCommandHandler::DummyCommand.new(aggregate_id: "1"))
     expect(command_handler.called).to eq "DummyCommand"
   end
 
   it "raises a CommandNotValid for invalid commands" do
-    expect { command_service.execute_commands(DummyBaseCommand.new) }.to raise_error(Sequent::Core::CommandNotValid)
+    expect { command_service.execute_commands(TestCommandHandler::DummyBaseCommand.new) }.to raise_error(Sequent::Core::CommandNotValid)
   end
 
   it "always clear repository after execute" do
-    expect { command_service.execute_commands(DummyBaseCommand.new) }.to raise_error(Sequent::Core::CommandNotValid)
+    expect { command_service.execute_commands(TestCommandHandler::DummyBaseCommand.new) }.to raise_error(Sequent::Core::CommandNotValid)
     expect(Thread.current[Sequent::Core::AggregateRepository::AGGREGATES_KEY]).to be_nil
   end
 
   context "command value parsing" do
+    it 'parses secrets using bcrypt when executing' do
+      command_service.execute_commands(TestCommandHandler::CommandWithSecret.new(password: 'secret'))
+
+      expect(Sequent::Secret.verify_secret(command_handler.password.value, 'secret')).to be_truthy
+      expect(command_handler.password.verify_secret('secret')).to be_truthy
+    end
+
     it "parses the values in the command if it is valid" do
-      command_service.execute_commands(WithIntegerCommand.new(aggregate_id: "1", value: "2"))
+      command_service.execute_commands(TestCommandHandler::WithIntegerCommand.new(aggregate_id: "1", value: "2"))
       expect(command_handler.called.value).to eq 2
     end
 
     it 'removes leading zeros if it is valid' do
-      command_service.execute_commands(WithIntegerCommand.new(aggregate_id: "1", value: "02"))
+      command_service.execute_commands(TestCommandHandler::WithIntegerCommand.new(aggregate_id: "1", value: "02"))
       expect(command_handler.called.value).to eq 2
     end
 
     it "does not parse values if the command is invalid" do
-      command = WithIntegerCommand.new(value: "A")
+      command = TestCommandHandler::WithIntegerCommand.new(value: "A")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
         expect(e.errors[:value]).to eq ['is not a number']
       end
     end
 
     it "does not removes leading zeros if command is invalid" do
-      command = WithIntegerCommand.new(aggregate_id: "1", value: "0x")
+      command = TestCommandHandler::WithIntegerCommand.new(aggregate_id: "1", value: "0x")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
         expect(e.errors[:value]).to eq ['is not a number']
       end
     end
 
     it "does not removes leading zeros when using hexadecimal values" do
-      command = WithIntegerCommand.new(aggregate_id: "1", value: "0x10")
+      command = TestCommandHandler::WithIntegerCommand.new(aggregate_id: "1", value: "0x10")
       expect { command_service.execute_commands(command) }.to raise_error do |e|
         expect(e.errors[:value]).to eq ['is not a number']
       end

--- a/spec/lib/sequent/core/helpers/secret_spec.rb
+++ b/spec/lib/sequent/core/helpers/secret_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+class SecretCommand < Sequent::Core::Command
+
+  def initialize(args = {})
+    super({aggregate_id: '1', name: 'Jari'}.merge(args))
+  end
+
+  attrs password: Sequent::Secret, name: String
+
+  validates_presence_of :name
+end
+
+describe 'commands with secrets' do
+  it 'handles nil' do
+    command = SecretCommand.new(password: nil)
+    command.valid?
+
+    command = command.parse_attrs_to_correct_types
+    expect(command.password).to be_nil
+  end
+
+  context 'with strings' do
+    it 'can set a secret' do
+      command = SecretCommand.new(password: 'foo')
+      expect(command.password).to eq 'foo'
+    end
+
+    it 'empties the secret when command is invalid' do
+      command = SecretCommand.new(password: 'foo', name: nil)
+      expect(command.password).to eq 'foo'
+
+      command.valid?
+      expect(command.password).to be_nil
+    end
+
+    it 'encrypts the password after validation' do
+      command = SecretCommand.new(password: 'foo', name: 'jari')
+      command.valid?
+
+      parsed_command = command.parse_attrs_to_correct_types
+
+      expect(parsed_command.password).to be_a(Sequent::Secret)
+      expect(parsed_command.password.verify_secret('foo')).to be_truthy
+      expect(parsed_command.password.verify_secret('f00')).to be_falsey
+    end
+  end
+
+  context 'with Sequent::Secret' do
+    it 'can set a secret' do
+      command = SecretCommand.new(password: Sequent::Secret.new('foo'))
+      expect(command.password).to eq Sequent::Secret.new('foo')
+    end
+
+    it 'encrypts the password after validation' do
+      command = SecretCommand.new(password: Sequent::Secret.new('foo'), name: 'jari')
+      command.valid?
+
+      parsed_command = command.parse_attrs_to_correct_types
+
+      expect(parsed_command.password).to be_a(Sequent::Secret)
+      expect(parsed_command.password.verify_secret('foo')).to be_truthy
+      expect(parsed_command.password.verify_secret('f00')).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Secrets can be used to encrypt values in Commands so its value
is never stored in plain text in the command_records table
in the database.