### PR TITLE
Be backward compatible with type String

### DIFF
--- a/docs/docs/concepts/types.md
+++ b/docs/docs/concepts/types.md
@@ -28,7 +28,7 @@ Out of the box Sequent supports the following types:
 
 Usage: `attrs name: String`
 
-Valid strings are `nil` or of type `String`.
+Valid strings are `nil` and anything that can be `to_s`-ed.
 There are some invalid characters like `"\0000"` postgres can't handle.
 
 When a String is considered invalid the error code `invalid_string` is

--- a/lib/sequent/core/ext/ext.rb
+++ b/lib/sequent/core/ext/ext.rb
@@ -6,7 +6,7 @@ end
 
 class String
   def self.deserialize_from_json(value)
-    value
+    value&.to_s
   end
 end
 

--- a/lib/sequent/core/helpers/string_to_value_parsers.rb
+++ b/lib/sequent/core/helpers/string_to_value_parsers.rb
@@ -7,7 +7,7 @@ module Sequent
       class StringToValueParsers
         PARSERS = {
           ::Symbol => ->(value) { Symbol.deserialize_from_json(value) },
-          ::String => ->(value) { value },
+          ::String => ->(value) { value&.to_s },
           ::Integer => ->(value) { parse_to_integer(value) },
           ::BigDecimal => ->(value) { parse_to_bigdecimal(value) },
           ::Float => ->(value) { parse_to_float(value) },

--- a/lib/sequent/core/helpers/value_validators.rb
+++ b/lib/sequent/core/helpers/value_validators.rb
@@ -42,7 +42,10 @@ module Sequent
 
         def self.valid_string?(value)
           return true if value.nil?
-          value.is_a?(String) && !INVALID_STRING_CHARS.any? { |invalid_char| value.include?(invalid_char) }
+          value.to_s && !INVALID_STRING_CHARS.any? { |invalid_char| value.to_s.include?(invalid_char) }
+        rescue => e
+          p foo: e
+          false
         end
 
         def self.for(klass)

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -55,7 +55,7 @@ describe Sequent::Core::Event do
     person = Person.new({name: "foo"})
     person.valid?
     event = TestEventEvent.new(
-      aggregate_id: 123, organization_id: "bar", sequence_number: 7, owner: person
+      aggregate_id: '123', organization_id: "bar", sequence_number: 7, owner: person
     )
     json = Sequent::Core::Oj.dump(event)
     other = TestEventEvent.deserialize_from_json(Sequent::Core::Oj.strict_load(json))
@@ -65,7 +65,7 @@ describe Sequent::Core::Event do
   it "is be able to converted from and to json with a date" do
     today = Date.today
     event = EventWithDate.new(
-      aggregate_id: 123, organization_id: "bar", sequence_number: 7, date_of_birth: today
+      aggregate_id: '123', organization_id: "bar", sequence_number: 7, date_of_birth: today
     )
     other = EventWithDate.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)))
     expect(other).to eq event
@@ -73,13 +73,13 @@ describe Sequent::Core::Event do
 
   it "fails when converting to and from Json when type is not supported" do
     event = EventWithUnknownAttributeType.new(
-      aggregate_id: 123, organization_id: "bar", sequence_number: 7, name: FooType.new
+      aggregate_id: '123', organization_id: "bar", sequence_number: 7, name: FooType.new
     )
     expect { EventWithUnknownAttributeType.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))) }.to raise_exception(NoMethodError)
   end
 
   it "converts symbols" do
-    event = EventWithSymbol.new(aggregate_id: 123, sequence_number: 7, organization_id: "bar", status: :foo)
+    event = EventWithSymbol.new(aggregate_id: '123', sequence_number: 7, organization_id: "bar", status: :foo)
     other = EventWithSymbol.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)))
     expect(event).to eq other
   end
@@ -91,7 +91,7 @@ describe Sequent::Core::Event do
   end
 
   it "deserializes nil symbols" do
-    event = EventWithSymbol.new(aggregate_id: 123, organization_id: "bar", sequence_number: 7)
+    event = EventWithSymbol.new(aggregate_id: '123', organization_id: "bar", sequence_number: 7)
     other = EventWithSymbol.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)))
     expect(event).to eq other
   end

--- a/spec/lib/sequent/core/helpers/string_validator_spec.rb
+++ b/spec/lib/sequent/core/helpers/string_validator_spec.rb
@@ -9,11 +9,11 @@ describe Sequent::Core::Helpers::StringValidator do
     attrs name: String
   end
 
-  it 'Strings must be of type String' do
+  it 'Anything that can be to_s-ed is a valid string' do
     command = StringValidatorCommand.new(name: 1)
-
-    expect(command.valid?).to_not be_truthy
-    expect(command.errors[:name]).to_not be_empty
+    command.valid?
+    expect(command.errors[:name]).to be_empty
+    expect(command.valid?).to be_truthy
   end
 
   it 'String can be nil' do


### PR DESCRIPTION
We allowed anything that could be `to_s`-ed in the past.
To not break existing events `to_s` all the input so it is really a String