### PR TITLE
BigDecimal.new is deprecated in ruby 2.6

### DIFF
--- a/lib/sequent/core/ext/ext.rb
+++ b/lib/sequent/core/ext/ext.rb
@@ -25,7 +25,7 @@ end
 class BigDecimal
   def self.deserialize_from_json(value)
     return nil if value.nil?
-    BigDecimal.new(value)
+    BigDecimal(value)
   end
 end
 

--- a/lib/sequent/core/helpers/string_to_value_parsers.rb
+++ b/lib/sequent/core/helpers/string_to_value_parsers.rb
@@ -24,7 +24,7 @@ module Sequent
         end
 
         def self.parse_to_bigdecimal(value)
-          BigDecimal.new(value) unless value.blank?
+          BigDecimal(value) unless value.blank?
         end
 
         def self.parse_to_float(value)

--- a/spec/lib/sequent/core/helpers/type_conversion_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/type_conversion_support_spec.rb
@@ -68,7 +68,7 @@ describe Sequent::Core::Helpers::TypeConversionSupport do
     it 'parses to a BigDecimal' do
       command = CommandWithBigDecimal.new(value: '10.10')
       command = command.parse_attrs_to_correct_types
-      expect(command.value).to eq BigDecimal.new('10.10')
+      expect(command.value).to eq BigDecimal('10.10')
     end
   end
 


### PR DESCRIPTION
I'm using Sequent with ruby 2.6.x and I get some deprecation warnings:

```
warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```

I think I fixed all occurrences.