### PR TITLE
Event record attributes

### DIFF
--- a/docs/docs/concepts/configuration.md
+++ b/docs/docs/concepts/configuration.md
@@ -105,6 +105,7 @@ For the most recent possibilities please check the `Sequent::Configuration` impl
 |event_record_class|The [class](event_store.html) mapped to the `event_records`|`Sequent::Core::EventRecord`|
 |stream_record_class|The [class](event_store.html) mapped to the `stream_records` table|`Sequent::Core::StreamRecord`|
 |snapshot_event_class|The event class marking something as a [Snapshot event](snapshotting.html)|`Sequent::Core::SnapshotEvent`|
+|event_record_hooks_class|The class with EventRecord life cycle hooks|`Sequent::Core::EventRecordHooks`|
 |transaction_provider|The transaction provider used by the [CommandService](command-service.html)|`Sequent::Core::Transactions::ActiveRecordTransactionProvider.new`|
 |event_publisher|The EventPublisher used by the [EventStore](event_store.html).|`Sequent::Core::EventPublisher.new`|
 |command_handlers|The list of [CommandHandlers](command-handler.html)|Empty|

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -24,6 +24,8 @@ module Sequent
     DEFAULT_OFFLINE_REPLAY_PERSISTOR_CLASS = Sequent::Core::Persistors::ActiveRecordPersistor
     DEFAULT_ONLINE_REPLAY_PERSISTOR_CLASS = Sequent::Core::Persistors::ActiveRecordPersistor
 
+    DEFAULT_EVENT_RECORD_HOOKS_CLASS = Sequent::Core::EventRecordHooks
+
     attr_accessor :aggregate_repository
 
     attr_accessor :event_store,
@@ -33,6 +35,8 @@ module Sequent
                   :snapshot_event_class,
                   :transaction_provider,
                   :event_publisher
+
+    attr_accessor :event_record_hooks_class
 
     attr_accessor :command_handlers,
                   :command_filters
@@ -91,6 +95,8 @@ module Sequent
       self.event_store_schema_name = DEFAULT_EVENT_STORE_SCHEMA_NAME
       self.migrations_class_name = MIGRATIONS_CLASS_NAME
       self.number_of_replay_processes = DEFAULT_NUMBER_OF_REPLAY_PROCESSES
+
+      self.event_record_hooks_class = DEFAULT_EVENT_RECORD_HOOKS_CLASS
 
       self.offline_replay_persistor_class = DEFAULT_OFFLINE_REPLAY_PERSISTOR_CLASS
       self.online_replay_persistor_class = DEFAULT_ONLINE_REPLAY_PERSISTOR_CLASS

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -4,6 +4,46 @@ require_relative 'sequent_oj'
 module Sequent
   module Core
 
+    # == Event Record Hooks
+    #
+    # These hooks are called during the life cycle of
+    # Sequent::Core::EventRecord. It is recommended to create a subclass of
+    # +Sequent::Core::EventRecordHooks+ when implementing this in your
+    # application.
+    #
+    #   Sequent.configure do |config|
+    #     config.event_record_hooks_class = MyApp::EventRecordHooks
+    #   end
+    #
+    #   module MyApp
+    #     class EventRecordHooks < Sequent::EventRecordHooks
+    #
+    #       # Adds additional metadata to the +event_records+ table.
+    #       def self.after_serialization(event_record, event)
+    #         event_record.metadata = event.metadata if event.respond_to?(:metadata)
+    #       end
+    #
+    #     end
+    #   end
+    class EventRecordHooks
+
+      # Called after assigning Sequent's event attributes to the +event_record+.
+      #
+      # *Params*
+      # - +event_record+ An instance of Sequent.configuration.event_record_class
+      # - +event+ An instance of the Sequent::Core::Event being persisted
+      #
+      #     class EventRecordHooks < Sequent::EventRecordHooks
+      #       def self.after_serialization(event_record, event)
+      #         event_record.seen_by_hook = true
+      #       end
+      #     end
+      def self.after_serialization(event_record, event)
+        # noop
+      end
+
+    end
+
     module SerializesEvent
       def event
         payload = Sequent::Core::Oj.strict_load(self.event_json)
@@ -17,6 +57,8 @@ module Sequent
         self.event_type = event.class.name
         self.created_at = event.created_at
         self.event_json = self.class.serialize_to_json(event)
+
+        Sequent.configuration.event_record_hooks_class.after_serialization(self, event)
       end
 
       module ClassMethods

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -187,18 +187,11 @@ SELECT aggregate_id
             event_stream.stream_record_id = stream_record.id
           end
           uncommitted_events.map do |event|
-            values = {
-              command_record_id: command_record.id,
-              stream_record_id: event_stream.stream_record_id,
-              aggregate_id: event.aggregate_id,
-              sequence_number: event.sequence_number,
-              event_type: event.class.name,
-              event_json: Sequent.configuration.event_record_class.serialize_to_json(event),
-              created_at: event.created_at
-            }
-            values = values.merge(organization_id: event.organization_id) if event.respond_to?(:organization_id)
-
-            Sequent.configuration.event_record_class.new(values)
+            Sequent.configuration.event_record_class.new.tap do |record|
+              record.command_record_id = command_record.id
+              record.stream_record_id = event_stream.stream_record_id
+              record.event = event
+            end
           end
         end
         connection = Sequent.configuration.event_record_class.connection

--- a/spec/lib/sequent/core/event_record_spec.rb
+++ b/spec/lib/sequent/core/event_record_spec.rb
@@ -86,6 +86,20 @@ describe Sequent::Core::EventRecord do
         record.event = event
         expect(record.organization_id).to eq('organization-id')
       end
+
+      it "invokes 'after_serialization' hook" do
+        event_record_hooks = spy(:event_record_hooks)
+        Sequent.configuration.event_record_hooks_class = event_record_hooks
+
+        event = ExampleEvent.new(
+          aggregate_id: 'aggregate-id',
+          sequence_number: 1
+        )
+
+        record = ExampleRecord.new
+        record.event = event
+        expect(event_record_hooks).to have_received(:after_serialization).with(record, event)
+      end
     end
   end
 end

--- a/spec/lib/sequent/core/event_record_spec.rb
+++ b/spec/lib/sequent/core/event_record_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+describe Sequent::Core::EventRecord do
+  describe Sequent::Core::SerializesEvent do
+    before do
+      stub_const("ExampleEvent", Class.new(Sequent::Core::Event))
+      stub_const("ExampleRecord", Class.new(Sequent::Core::EventRecord))
+
+      ExampleEvent.class_eval do
+        attrs name: String, age: Integer
+      end
+    end
+
+    context "event" do
+      it "initializes an event type from json" do
+        record = ExampleRecord.new({
+          event_type: ExampleEvent.name,
+          event_json: {
+            aggregate_id: 'example-id',
+            sequence_number: 1,
+            name: "example-name",
+            age: 58,
+            created_at: DateTime.new(2019, 1, 1)
+          }.to_json
+        })
+
+        expect(record.event).to eq(ExampleEvent.new(
+          aggregate_id: 'example-id',
+          sequence_number: 1,
+          name: 'example-name',
+          age: 58,
+          created_at: DateTime.new(2019, 1, 1)
+        ))
+      end
+    end
+
+    context "event=" do
+      it "assigns attributes from an event" do
+        aggregate_id = 'aggregate-id'
+        sequence_number = 1
+        created_at = DateTime.new(2019, 1, 1)
+
+        event = ExampleEvent.new(
+          aggregate_id: aggregate_id,
+          sequence_number: sequence_number,
+          created_at: created_at
+        )
+
+        record = ExampleRecord.new
+        record.event = event
+
+        expect(record.aggregate_id).to eq(aggregate_id)
+        expect(record.sequence_number).to eq(sequence_number)
+        expect(record.event_type).to eq('ExampleEvent')
+        expect(record.created_at).to eq(created_at)
+        expect(record.event_json).to eq(ExampleRecord.serialize_to_json(event))
+      end
+
+      it "conditionally assigns organization_id" do
+        stub_const("EventWithOrganizationId", Class.new(Sequent::Core::Event))
+
+        ExampleRecord.class_eval do
+          attr_accessor :organization_id
+        end
+
+        record = ExampleRecord.new
+
+        event = ExampleEvent.new(
+          aggregate_id: 'aggregate-id',
+          sequence_number: 1
+        )
+
+        record.event = event
+        expect(record.organization_id).to be_nil
+
+        EventWithOrganizationId.class_eval do
+          attrs organization_id: String
+        end
+
+        event = EventWithOrganizationId.new(
+          aggregate_id: 'aggregate-id',
+          sequence_number: 1,
+          organization_id: 'organization-id'
+        )
+
+        record.event = event
+        expect(record.organization_id).to eq('organization-id')
+      end
+    end
+  end
+end


### PR DESCRIPTION
First of all, I'd like to thank you for this framework. I'm just getting started with event sourcing and your project and documentation have been a great benefit for me to understand how this all works. Being familiar with ActiveRecord makes this project appealing and `ReplayOptimizedPostgresPersistor` looks awesome.

In my application I'm wanting to add [metadata] and [correlation/causation ids][correlation_causation] to the `event_records` table. I'm introducing this change to take advantage of `SerializesEvent#event=` to remove duplication and also allow a subclass of `EventRecord` to write additional columns from the event.

**Usage**

```ruby
class AppEventRecord < Sequent::Core::EventRecord
  def event=(event)
    super
    self.correlation_id = event.correlation_id if event.respond_to?(:correlation_id)
    self.causation_id = event.correlation_id if event.respond_to?(:causation_id)
    self.metadata_json = self.class.serialize_to_json(event.metadata) if event.respond_to?(:metadata)
  end
end
```

[metadata]: https://railseventstore.org/docs/request_metadata/
[correlation_causation]: https://railseventstore.org/docs/correlation_causation/