### PR TITLE
Add `after_commit` to workflows

### DIFF
--- a/docs/docs/concepts/workflow.md
+++ b/docs/docs/concepts/workflow.md
@@ -2,13 +2,13 @@
 title: Workflow
 ---
 
-Workflows can be used to do other stuff (then updating a Projection) based on [Events](event.html). Common
+Workflows can be used to do other stuff (than updating a Projection) based on [Events](event.html). Common
 tasks run by Workflows are:
 
 1. Execute other [Commands](command.html)
 2. Schedule something to run in the background
 
-In Sequent Workflows are committed in the same transaction as committing the Events.
+In Sequent, Workflows are committed in the same transaction as committing the Events.
 
 Since Workflows have nothing to do with Projections they do **not** run when doing a [Migration](migrations.html).
 
@@ -22,17 +22,16 @@ Sequent.configure do |config|
 end
 ```
 
-A Workflow responds to Event basically the same as Projectors do. For instance a Workflow
+A Workflow responds to Events basically the same way as Projectors do. For instance a Workflow
 that will schedule a background Job using [DelayedJob](https://github.com/collectiveidea/delayed_job)
 can look like this:
 
 ```ruby
 class SendEmailWorkflow < Sequent::Workflow
   on UserCreated do |event|
-    Delayed::Job.enqueue(event)
+    Delayed::Job.enqueue UserJob.new(event)
   end
 end
-
 
 class UserJob
   def initialize(event)
@@ -44,4 +43,29 @@ class UserJob
   end
 end
 ```
+
+If your Workflow has some side effects that can't be rolled back easily or if your background jobs processor
+is not using the same database connection used for the transaction, you can wrap it in an `after_commit` block:
+
+```ruby
+class SendEmailWorkflow < Sequent::Workflow
+  on UserCreated do |event|
+    after_commit do
+      SendEmailJob.perform_async(event)
+    end
+  end
+end
+
+class SendEmailJob
+  include Sidekiq::Worker
+
+  def perform(event)
+    ExternalService.send_email_to_user('Welcome User!', event.user_email_address)
+  end
+end
+```
+
+It will run only and only if the transaction commits. Note that if you execute another command, it will be ran
+synchronously but in a separate transaction. It will not be able to rollback the first one, resulting in some
+Events to be commited and some other not. Only use `after_commit` if it is the intended behaviour.
 

--- a/docs/docs/concepts/workflow.md
+++ b/docs/docs/concepts/workflow.md
@@ -69,3 +69,7 @@ It will run only and only if the transaction commits. Note that if you execute a
 synchronously but in a separate transaction. It will not be able to rollback the first one, resulting in some
 Events to be commited and some other not. Only use `after_commit` if it is the intended behaviour.
 
+**Handling Exceptions**: If an exception within an `after_commit` is not handled by the worker, it will stop
+calling the other registered hooks. Make sure that you **rescue exceptions** and handle them properly. If you can
+afford to ignore the errors and want to make sure all hooks are called, you can pass `ignore_errors: true` as a parameter.
+{: .notice--warning}

--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -9,6 +9,11 @@ module Sequent
           end
         end
 
+        def after_commit
+          ActiveRecord::Base.after_commit do
+            yield
+          end
+        end
       end
 
     end

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -5,8 +5,17 @@ module Sequent
     class Workflow
       include Helpers::MessageHandler
 
+      def self.on(*args, after_commit: false, &block)
+        block = Proc.new { after_commit &block } if after_commit
+        super(*args, block)
+      end
+
       def execute_commands(*commands)
         Sequent.configuration.command_service.execute_commands(*commands)
+      end
+
+      def after_commit(&block)
+        Sequent.configuration.transaction_provider.after_commit &block
       end
     end
   end

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -16,8 +16,14 @@ module Sequent
       # back when there is an exception. Useful if your background
       # jobs processor is not using the same database connection
       # to enqueue jobs.
-      def after_commit(&block)
+      def after_commit(ignore_errors: false, &block)
         Sequent.configuration.transaction_provider.after_commit &block
+      rescue StandardError => error
+        if ignore_errors
+          Sequent.logger.warn("An exception was raised in an after_commit hook: #{error}, #{error.inspect}")
+        else
+          raise error
+        end
       end
     end
   end

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -5,11 +5,6 @@ module Sequent
     class Workflow
       include Helpers::MessageHandler
 
-      def self.on(*args, after_commit: false, &block)
-        block = Proc.new { after_commit &block } if after_commit
-        super(*args, block)
-      end
-
       def execute_commands(*commands)
         Sequent.configuration.command_service.execute_commands(*commands)
       end

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -9,6 +9,13 @@ module Sequent
         Sequent.configuration.command_service.execute_commands(*commands)
       end
 
+      # Workflow#after_commit will accept a block to execute
+      # after the transaction commits. This is very useful to
+      # isolate side-effects. They will run only on the
+      # transaction's success and will not be able to roll it
+      # back when there is an exception. Useful if your background
+      # jobs processor is not using the same database connection
+      # to enqueue jobs.
       def after_commit(&block)
         Sequent.configuration.transaction_provider.after_commit &block
       end

--- a/spec/lib/sequent/core/workflow_spec.rb
+++ b/spec/lib/sequent/core/workflow_spec.rb
@@ -4,6 +4,8 @@ require 'sequent/test/event_handler_helpers'
 describe Sequent::Core::Workflow do
   include Sequent::Test::WorkflowHelpers
 
+  class CreateNotification < Sequent::Core::BaseCommand; end
+
   class UserWasRegistered < Sequent::Core::Event
     attrs email: String
   end
@@ -14,14 +16,24 @@ describe Sequent::Core::Workflow do
 
   class RegistrationWorkflow < Sequent::Core::Workflow
     on UserWasRegistered do |e|
-      execute_commands SendWelcomeEmail.new(email: e.email)
+      execute_commands CreateNotification.new(aggregate_id: e.aggregate_id)
+
+      after_commit do
+        execute_commands SendWelcomeEmail.new(email: e.email)
+      end
     end
   end
 
   let(:workflow) { RegistrationWorkflow.new }
 
+  let(:notification_command) { CreateNotification.new(aggregate_id: 'user') }
+  let(:email_command) { SendWelcomeEmail.new(aggregate_id: 'user', email: 'user@example.com') }
+
   it 'executes commands' do
-    when_event UserWasRegistered.new(aggregate_id: 'user', sequence_number: 1, email: 'user@example.com')
-    then_commands SendWelcomeEmail.new(aggregate_id: 'user', email: 'user@example.com')
+    fake_transaction_provider.transactional do
+      when_event UserWasRegistered.new(aggregate_id: 'user', sequence_number: 1, email: 'user@example.com')
+      then_commands notification_command
+    end
+    then_commands notification_command, email_command
   end
 end


### PR DESCRIPTION
As discussed in #168 , I created a helper to let a Workflow run side effects after a transaction commits. I also documented the feature.

It is basically used like this:

```ruby
class SendEmailWorkflow < Sequent::Workflow
  on UserCreated do |event|
    after_commit do
      # code with side effects
    end
  end
end
```

closes #168 