### PR TITLE
Fix the after_commit hook

### DIFF
--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -13,7 +13,7 @@ module Sequent
         end
 
         def after_commit(&block)
-          Thread.current[:after_commit_queue] << block
+          after_commit_queue << block
         end
 
         private

--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -7,12 +7,23 @@ module Sequent
           ActiveRecord::Base.transaction(requires_new: true) do
             yield
           end
+          after_commit_queue.each &:call
+        ensure
+          clear_after_commit_queue
         end
 
-        def after_commit
-          ActiveRecord::Base.after_commit do
-            yield
-          end
+        def after_commit(&block)
+          Thread.current[:after_commit_queue] << block
+        end
+
+        private
+
+        def after_commit_queue
+          Thread.current[:after_commit_queue] ||= []
+        end
+
+        def clear_after_commit_queue
+          Thread.current[:after_commit_queue] = []
         end
       end
 


### PR DESCRIPTION
I'm going to start by saying that I am a bit embarrassed by this. My last pull-request was not sufficiently tested in "real-world" scenario and I quickly came to the realisation that I misunderstood how ActiveRecord's `after_commit` was behaving. Not only it called the block for each operation committed in the transaction, it was not clearing it's queue after the transaction was done.

I changed the ActiveRecordTransactionProvider's `after_commit` implementation to let it manage its hook. There was other solutions, like using [after_transaction_commit](https://github.com/instructure/after_transaction_commit) or [after_commit_everywhere](https://github.com/Envek/after_commit_everywhere) but I did not want to introduce a new dependency to the project. 

If you'd prefer another implementation to fix that issue, I'm ready to change it. 