### PR TITLE
Only set existing attributes on `CommandRecord`

### DIFF
--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -13,12 +13,21 @@ module Sequent
       def command=(command)
         self.created_at = command.created_at
         self.aggregate_id = command.aggregate_id if command.respond_to? :aggregate_id
-        self.organization_id = command.organization_id if command.respond_to? :organization_id
         self.user_id = command.user_id if command.respond_to? :user_id
         self.command_type = command.class.name
         self.command_json = Sequent::Core::Oj.dump(command.attributes)
-        self.event_aggregate_id = command.event_aggregate_id if command.respond_to? :event_aggregate_id
-        self.event_sequence_number = command.event_sequence_number if command.respond_to? :event_sequence_number
+
+        # optional attributes (here for historic reasons)
+        # this should be moved to a configurable CommandSerializer
+        self.organization_id = command.organization_id if serialize_attribute?(command, :organization_id)
+        self.event_aggregate_id = command.event_aggregate_id if serialize_attribute?(command, :event_aggregate_id)
+        self.event_sequence_number = command.event_sequence_number if serialize_attribute?(command, :event_sequence_number)
+      end
+
+      private
+
+      def serialize_attribute?(command, attribute)
+        [self, command].all? { |obj| obj.respond_to?(attribute) }
       end
     end
 

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Sequent
-  VERSION = '3.2.0'
+  VERSION = '3.2.1'
 end

--- a/spec/lib/sequent/core/serializes_command_spec.rb
+++ b/spec/lib/sequent/core/serializes_command_spec.rb
@@ -5,13 +5,13 @@ describe Sequent::Core::SerializesCommand do
   class RecordMock
     include Sequent::Core::SerializesCommand
     attr_accessor :aggregate_id,
-                  :created_at,
-                  :user_id,
-                  :command_type,
-                  :command_json,
-                  :event_aggregate_id,
-                  :event_sequence_number
-
+      :created_at,
+      :user_id,
+      :command_type,
+      :command_json,
+      :event_aggregate_id,
+      :event_sequence_number,
+      :organization_id
   end
 
   class RecordValueObject < Sequent::Core::ValueObject
@@ -19,13 +19,13 @@ describe Sequent::Core::SerializesCommand do
   end
 
   class RecordCommand < Sequent::Core::Command
-    attrs value: RecordValueObject
+    attrs value: RecordValueObject, organization_id: String
   end
 
   let(:value_object) { RecordValueObject.new }
   let(:command) { RecordCommand.new(aggregate_id: "1",
-                                    user_id: "ben en kim",
-                                    value: value_object) }
+    user_id: "ben en kim",
+    value: value_object) }
 
   describe ".command" do
     it 'only serializes declared attrs' do
@@ -39,5 +39,40 @@ describe Sequent::Core::SerializesCommand do
       expect(payload["value"]).to_not have_key("errors")
       expect(payload["value"]).to have_key("value")
     end
+
+    describe 'optional fields' do
+      class MyRecord
+        include Sequent::Core::SerializesCommand
+        attr_accessor :aggregate_id,
+          :created_at,
+          :user_id,
+          :command_type,
+          :command_json
+
+        def initialize(aggregate_id, created_at, user_id, command_type, command_json)
+          @aggregate_id = aggregate_id
+          @created_at = created_at
+          @user_id = user_id
+          @command_type = command_type
+          @command_json = command_json
+        end
+      end
+
+      let(:record) {
+        MyRecord.new(
+          Sequent.new_uuid,
+          DateTime.now,
+          Sequent.new_uuid,
+          RecordCommand.name,
+          {}
+        )
+      }
+
+      it 'should not fail' do
+        record.command=command
+      end
+
+    end
   end
+
 end


### PR DESCRIPTION
Some attributes are optional:

- organization_id
- event_aggregate_id
- event_sequence_number

So only set these on the CommandRecord if they are present
in the `Command` and the `CommandRecord`.