### PR TITLE
Allow 3.x versions of oj

### DIFF
--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'activemodel', active_star_version
   s.add_dependency              'pg', '~> 1.0'
   s.add_dependency              'postgresql_cursor', '~> 0.6'
-  s.add_dependency              'oj', '~> 3.3.9'
+  s.add_dependency              'oj', '~> 3.0'
   s.add_dependency              'thread_safe', '~> 0.3.5'
   s.add_dependency              'parallel', '~> 1.12.1'
   s.add_dependency              'bcrypt', '~> 3.1'


### PR DESCRIPTION
This changes the version pin from `3.3.x` to `3.x` for the `oj` gem. Looking at the [changelog](https://github.com/ohler55/oj/blob/master/CHANGELOG.md) there are lots of useful bug fixes.

I ran the tests and they all passed:
```
Finished in 58.01 seconds (files took 1.04 seconds to load)
367 examples, 0 failures, 1 pending
```