### PR TITLE
Make Boolean a module

### DIFF
--- a/lib/sequent/core/ext/ext.rb
+++ b/lib/sequent/core/ext/ext.rb
@@ -29,7 +29,7 @@ class BigDecimal
   end
 end
 
-class Boolean
+module Boolean
   def self.deserialize_from_json(value)
     value.nil? ? nil : (value.present? ? value : false)
   end


### PR DESCRIPTION
See #185

In short, it seems like the goals of `Boolean` can be accomplished with it as a module, especially considering that there doesn't seem to be an expectation that `Boolean` will be instantiated. This also makes it more compatible with existing patterns, e.g.

```ruby
module Boolean; end
TrueClass.include Boolean
FalseClass.include Boolean

true.is_a? Boolean # => true
false.is_a? Boolean # => true
```