### PR TITLE
Replace ActiveRecord::Base with Sequent::ApplicationRecord

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require_relative 'lib/version'
+require_relative 'lib/sequent/application_record'
 require_relative 'spec/database'
 
 begin

--- a/docs/docs/building-a-web-application.md
+++ b/docs/docs/building-a-web-application.md
@@ -144,8 +144,8 @@ class Database
     def establish_connection(env = ENV['RACK_ENV'])
       config = database_config(env)
       yield(config) if block_given?
-      ActiveRecord::Base.configurations[env.to_s] = config.stringify_keys
-      ActiveRecord::Base.establish_connection config
+      Sequent::ApplicationRecord.configurations[env.to_s] = config.stringify_keys
+      Sequent::ApplicationRecord.establish_connection config
     end
   end
 end
@@ -177,7 +177,7 @@ class Web < Sinatra::Base
   ...
 
   after do
-    ActiveRecord::Base.clear_active_connections!
+    Sequent::ApplicationRecord.clear_active_connections!
   end
 
   ...
@@ -222,7 +222,7 @@ Since we are using `ActiveRecord` we need to create the `AuthorRecord`
 
 `app/records/author_record.rb`
 ```ruby
-class AuthorRecord < ActiveRecord::Base
+class AuthorRecord < Sequent::ApplicationRecord
 end
 ```
 

--- a/docs/docs/concepts/projector.md
+++ b/docs/docs/concepts/projector.md
@@ -8,7 +8,7 @@ describe the Projections. In Sequent Projectors inherit from `Sequent::Projector
 in a Projection you need 3 things in `Sequent`:
 
 1. A Projector. Responsible for creating Projections. We are discussing Projectors in this chapter.
-2. A Record class. This is a normal `ActiveRecord::Base` class. In Sequent Records can **only be updated/created/deleted
+2. A Record class. This is a `Sequent::ApplicationRecord` class, subclassing  `ActiveRecord::Base`. In Sequent Records can **only be updated/created/deleted
     inside Projectors**. The rest of the application needs to regard these objects as **read-only**.
     This however is **not enforced** in Sequent.
 3. A SQL file. The SQL contains the table definition in which the Record will be stored. Please checkout the chapter

--- a/lib/sequent.rb
+++ b/lib/sequent.rb
@@ -1,3 +1,4 @@
+require_relative 'sequent/application_record'
 require_relative 'sequent/sequent'
 require_relative 'sequent/core/core'
 require_relative 'sequent/util/util'

--- a/lib/sequent/application_record.rb
+++ b/lib/sequent/application_record.rb
@@ -1,0 +1,7 @@
+require 'active_record'
+
+module Sequent
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -32,7 +32,7 @@ module Sequent
     end
 
     # For storing Sequent::Core::Command in the database using active_record
-    class CommandRecord < ActiveRecord::Base
+    class CommandRecord < Sequent::ApplicationRecord
       include SerializesCommand
 
       self.table_name = "command_records"

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -72,7 +72,7 @@ module Sequent
       end
     end
 
-    class EventRecord < ActiveRecord::Base
+    class EventRecord < Sequent::ApplicationRecord
       include SerializesEvent
 
       self.table_name = "event_records"

--- a/lib/sequent/core/persistors/active_record_persistor.rb
+++ b/lib/sequent/core/persistors/active_record_persistor.rb
@@ -104,7 +104,7 @@ module Sequent
         end
 
         def execute_sql(statement)
-          ActiveRecord::Base.connection.execute(statement)
+          Sequent::ApplicationRecord.connection.execute(statement)
         end
 
         def commit

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -307,7 +307,7 @@ module Sequent
               end
 
               buf = ''
-              conn = ActiveRecord::Base.connection.raw_connection
+              conn = Sequent::ApplicationRecord.connection.raw_connection
               copy_data = StringIO.new csv.string
               conn.transaction do
                 conn.copy_data("COPY #{clazz.table_name} (#{column_names.join(",")}) FROM STDIN WITH csv") do
@@ -346,7 +346,7 @@ module Sequent
         private
 
         def cast_value_to_column_type(clazz, column_name, record)
-          ActiveRecord::Base.connection.type_cast(record[column_name.to_sym], @column_cache[clazz.name][column_name])
+          Sequent::ApplicationRecord.connection.type_cast(record[column_name.to_sym], @column_cache[clazz.name][column_name])
         end
       end
     end

--- a/lib/sequent/core/stream_record.rb
+++ b/lib/sequent/core/stream_record.rb
@@ -13,7 +13,7 @@ module Sequent
       end
     end
 
-    class StreamRecord < ActiveRecord::Base
+    class StreamRecord < Sequent::ApplicationRecord
 
       self.table_name = "stream_records"
 

--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -4,7 +4,7 @@ module Sequent
 
       class ActiveRecordTransactionProvider
         def transactional
-          ActiveRecord::Base.transaction(requires_new: true) do
+          Sequent::ApplicationRecord.transaction(requires_new: true) do
             yield
           end
           after_commit_queue.each &:call

--- a/lib/sequent/generator/template_project/app/records/post_record.rb
+++ b/lib/sequent/generator/template_project/app/records/post_record.rb
@@ -1,2 +1,2 @@
-class PostRecord < ActiveRecord::Base
+class PostRecord < Sequent::ApplicationRecord
 end

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -43,8 +43,8 @@ module Sequent
       include Sequent::Util::Timer
       include Sequent::Util::Printer
 
-      class Versions < ActiveRecord::Base; end
-      class ReplayedIds < ActiveRecord::Base; end
+      class Versions < Sequent::ApplicationRecord; end
+      class ReplayedIds < Sequent::ApplicationRecord; end
 
       attr_reader :view_schema, :db_config, :logger
 
@@ -161,7 +161,7 @@ module Sequent
         replay!(projectors_to_migrate, Sequent.configuration.offline_replay_persistor_class.new, exclude_ids: true, group_exponent: 1)
 
         in_view_schema do
-          ActiveRecord::Base.transaction do
+          Sequent::ApplicationRecord.transaction do
             for_each_table_to_migrate do |table|
               current_table_name = table.table_name.gsub("_#{Sequent.new_version}", "")
               # 2 Rename old table
@@ -360,7 +360,7 @@ module Sequent
       end
 
       def exec_sql(sql)
-        ActiveRecord::Base.connection.execute(sql)
+        Sequent::ApplicationRecord.connection.execute(sql)
       end
     end
   end

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -117,7 +117,7 @@ module Sequent
             end
 
             task :delete_all => ['sequent:init', :init] do
-              result = ActiveRecord::Base.connection.execute("DELETE FROM #{Sequent.configuration.event_record_class.table_name} WHERE event_type = 'Sequent::Core::SnapshotEvent'")
+              result = Sequent::ApplicationRecord.connection.execute("DELETE FROM #{Sequent.configuration.event_record_class.table_name} WHERE event_type = 'Sequent::Core::SnapshotEvent'")
               Sequent.logger.info "Deleted #{result.cmd_tuples} aggregate snapshots from the event store"
             end
           end

--- a/lib/sequent/rake/tasks.rb
+++ b/lib/sequent/rake/tasks.rb
@@ -57,7 +57,7 @@ module Sequent
 
           task :establish_connection do
             env_db = db_config(options.fetch(:environment))
-            Sequent::Support::Database.establish_connection(env_db)
+            ActiveRecord::Base.establish_connection(env_db)
           end
 
           desc 'Migrate the database'

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -66,7 +66,6 @@ module Sequent
         ActiveRecord::Base.establish_connection db_config
 
         yield
-
       ensure
         disconnect!
         db_config['schema_search_path'] = original_search_paths
@@ -102,7 +101,6 @@ module Sequent
         else
           ActiveRecord::Migrator.migrate(migrations_path)
         end
-
       end
     end
   end

--- a/spec/fixtures/db/1/classes.rb
+++ b/spec/fixtures/db/1/classes.rb
@@ -1,7 +1,7 @@
 require 'active_record'
 
-class AccountRecord < ActiveRecord::Base; end
-class MessageRecord < ActiveRecord::Base; end
+class AccountRecord < Sequent::ApplicationRecord; end
+class MessageRecord < Sequent::ApplicationRecord; end
 
 class Account < Sequent::Core::AggregateRoot; end
 class AccountCreated < Sequent::Core::Event; end

--- a/spec/lib/sequent/core/persistors/active_record_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/active_record_persistor_spec.rb
@@ -3,7 +3,7 @@ require 'tmpdir'
 require 'sequent/support'
 require_relative '../../migration_class'
 
-class ActiveRecordPersistorTest < ActiveRecord::Base; end
+class ActiveRecordPersistorTest < Sequent::ApplicationRecord; end
 
 describe Sequent::Core::Persistors::ActiveRecordPersistor do
   let(:migrations_path) { File.expand_path(database_name, Dir.tmpdir).tap { |dir| Dir.mkdir(dir) } }
@@ -15,7 +15,7 @@ describe Sequent::Core::Persistors::ActiveRecordPersistor do
   end
   before do
     Sequent::Support::Database.create!(db_config)
-    Sequent::Support::Database.establish_connection(db_config)
+    ActiveRecord::Base.establish_connection(db_config)
   end
   after { Sequent::Support::Database.drop!(db_config) }
 

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -204,7 +204,7 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
   end
 
   context 'committing' do
-    class ReplayOptimizedPostgresTest < ActiveRecord::Base; end
+    class ReplayOptimizedPostgresTest < Sequent::ApplicationRecord; end
 
     let(:migrations_path) { File.expand_path(database_name, Dir.tmpdir).tap { |dir| Dir.mkdir(dir) } }
     let(:database_name) { Sequent.new_uuid }

--- a/spec/lib/sequent/migrations/view_schema_spec.rb
+++ b/spec/lib/sequent/migrations/view_schema_spec.rb
@@ -38,7 +38,7 @@ describe Sequent::Migrations::ViewSchema do
     it 'creates the schema if not exists' do
       migrator.create_view_schema_if_not_exists
 
-      expect(ActiveRecord::Base.connection).to have_schema(view_schema)
+      expect(Sequent::ApplicationRecord.connection).to have_schema(view_schema)
     end
 
     it 'creates the migration table' do
@@ -51,7 +51,7 @@ describe Sequent::Migrations::ViewSchema do
       migrator.create_view_schema_if_not_exists
       migrator.create_view_schema_if_not_exists
 
-      expect(ActiveRecord::Base.connection).to have_schema(view_schema)
+      expect(Sequent::ApplicationRecord.connection).to have_schema(view_schema)
     end
 
   end
@@ -110,8 +110,8 @@ describe Sequent::Migrations::ViewSchema do
       it 'creates the new view tables with the version as suffix' do
         migrator.migrate_online
 
-        expect(ActiveRecord::Base.connection).to have_view_schema_table('account_records_1')
-        expect(ActiveRecord::Base.connection).to have_view_schema_table('message_records_1')
+        expect(Sequent::ApplicationRecord.connection).to have_view_schema_table('account_records_1')
+        expect(Sequent::ApplicationRecord.connection).to have_view_schema_table('message_records_1')
       end
 
       it 'cleans old migration tables before migrating' do
@@ -122,8 +122,8 @@ describe Sequent::Migrations::ViewSchema do
 
         migrator.migrate_online
 
-        expect(ActiveRecord::Base.connection).to_not have_view_schema_table('account_records_0')
-        expect(ActiveRecord::Base.connection).to have_view_schema_table('account_records_1')
+        expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('account_records_0')
+        expect(Sequent::ApplicationRecord.connection).to have_view_schema_table('account_records_1')
       end
 
       it 'replays the data and keeps track of the migrated ids' do
@@ -168,7 +168,7 @@ describe Sequent::Migrations::ViewSchema do
           expect(AccountRecord.count).to eq 2
 
           expect(MessageRecord.table_name).to eq 'message_records'
-          expect(ActiveRecord::Base.connection).to_not have_view_schema_table('message_records_1')
+          expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('message_records_1')
 
           expect(Sequent::Migrations::ViewSchema::ReplayedIds.pluck(:event_id)).to match_array Sequent.configuration.event_record_class.where(aggregate_id: [account_1, account_2]).pluck(:id)
         end
@@ -188,7 +188,7 @@ describe Sequent::Migrations::ViewSchema do
 
         expect { migrator.migrate_online }.to raise_error(Parallel::UndumpableException)
 
-        expect(ActiveRecord::Base.connection).to_not have_view_schema_table('account_records_1')
+        expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('account_records_1')
         expect(Sequent::Migrations::ViewSchema::ReplayedIds.count).to eq 0
       end
     end
@@ -334,8 +334,8 @@ describe Sequent::Migrations::ViewSchema do
 
         expect { migrator.migrate_offline }.to raise_error(Parallel::UndumpableException)
 
-        expect(ActiveRecord::Base.connection).to_not have_view_schema_table('message_records')
-        expect(ActiveRecord::Base.connection).to_not have_view_schema_table('account_records')
+        expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('message_records')
+        expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('account_records')
         expect(Sequent::Migrations::ViewSchema::ReplayedIds.count).to eq 0
       end
 
@@ -369,8 +369,8 @@ describe Sequent::Migrations::ViewSchema do
           end
           migrator.migrate_online
 
-          expect(ActiveRecord::Base.connection).to have_view_schema_table('message_records_2')
-          expect(ActiveRecord::Base.connection).to have_view_schema_table('account_records_2')
+          expect(Sequent::ApplicationRecord.connection).to have_view_schema_table('message_records_2')
+          expect(Sequent::ApplicationRecord.connection).to have_view_schema_table('account_records_2')
 
           account_id_2 = Sequent.new_uuid
           # force and error on replay by violating unique index in account_records
@@ -378,8 +378,8 @@ describe Sequent::Migrations::ViewSchema do
 
           expect { migrator.migrate_offline }.to raise_error(Parallel::UndumpableException)
 
-          expect(ActiveRecord::Base.connection).to_not have_view_schema_table('message_records_2')
-          expect(ActiveRecord::Base.connection).to_not have_view_schema_table('account_records_2')
+          expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('message_records_2')
+          expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('account_records_2')
 
           expect(Sequent::Migrations::ViewSchema::ReplayedIds.count).to eq 0
           expect(Sequent::Migrations::ViewSchema::Versions.maximum(:version)).to eq 1

--- a/spec/lib/sequent/support/database_spec.rb
+++ b/spec/lib/sequent/support/database_spec.rb
@@ -35,9 +35,9 @@ describe Sequent::Support::Database do
         Sequent::Support::Database.drop!(db_config)
       end
 
-      it 'connects the ActiveRecord::Base pool' do
+      it 'connects the Sequent::ApplicationRecord pool' do
         Sequent::Support::Database.establish_connection(db_config)
-        expect(ActiveRecord::Base.connection).to be_active
+        expect(Sequent::ApplicationRecord.connection).to be_active
       end
     end
   end
@@ -102,7 +102,7 @@ EOF
   end
 
   def database_exists?
-    results = ActiveRecord::Base.connection.select_all %Q(
+    results = Sequent::ApplicationRecord.connection.select_all %Q(
 SELECT 1 FROM pg_database
  WHERE datname = '#{database_name}'
 )
@@ -110,7 +110,7 @@ SELECT 1 FROM pg_database
   end
 
   def table_exists?(table_name)
-    results = ActiveRecord::Base.connection.select_all %Q(
+    results = Sequent::ApplicationRecord.connection.select_all %Q(
 SELECT 1 FROM pg_tables
  WHERE tablename = '#{table_name}'
 )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ SimpleCov.start if ENV["COVERAGE"]
 
 require_relative 'database'
 Database.establish_connection
-ActiveRecord::Base.connection.execute("TRUNCATE command_records, stream_records CASCADE")
+Sequent::ApplicationRecord.connection.execute("TRUNCATE command_records, stream_records CASCADE")
 
 RSpec.configure do |c|
   c.before do
@@ -19,7 +19,7 @@ RSpec.configure do |c|
   end
 
   def exec_sql(sql)
-    ActiveRecord::Base.connection.execute(sql)
+    Sequent::ApplicationRecord.connection.execute(sql)
   end
 
   def insert_events(aggregate_type, events)


### PR DESCRIPTION
Subclassing `ActiveRecord::Base` allows applications to isolate the connection for sequent, e.g. with a separate schema search path.