### PR TITLE
Ensure correct attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Changes since 3.2
+
+- Introduced `strict_check_attributes_on_apply_events`. Sequent will fail when calling `apply` with unknown attributes.
+
+
 # Changelog 3.2
 
 Introduces optional `event_aggregate_id` and `event_sequence_number` columns to the `command_records` table.

--- a/docs/docs/concepts/configuration.md
+++ b/docs/docs/concepts/configuration.md
@@ -120,6 +120,7 @@ For the most recent possibilities please check the `Sequent::Configuration` impl
 |number_of_replay_processes|The [number of process](#number_of_replay_processes) used while offline migration|`4`|
 |database_config_directory|The directory in which db config can be found|`db`|
 |event_store_schema_name|The name of the db schema in which the [EventStore](event_store.html) is installed|`sequent_schema`|
+|strict_check_attributes_on_apply_events|Whether or not sequent should fail on calling `apply` with invalid attributes.|`false`. Will be enabled by default in the next major release.|
 |migrations_class_name|The name of the [class](#minimum-configuration) containing the migrations|Empty|
 |versions_table_name|The name of the table in which Sequent checks which [migration version](migrations.html) is currently active|`sequent_versions`|
 |replayed_ids_table_name|The name of the table in which Sequent keeps track of which events are already replayed during a [migration](migrations.html)|`sequent_replayed_ids`|

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -26,6 +26,8 @@ module Sequent
 
     DEFAULT_EVENT_RECORD_HOOKS_CLASS = Sequent::Core::EventRecordHooks
 
+    DEFAULT_STRICT_CHECK_ATTRIBUTES_ON_APPLY_EVENTS = false
+
     attr_accessor :aggregate_repository
 
     attr_accessor :event_store,
@@ -49,6 +51,7 @@ module Sequent
 
     attr_accessor :logger
 
+
     attr_accessor :migration_sql_files_directory,
                   :view_schema_name,
                   :offline_replay_persistor_class,
@@ -56,6 +59,8 @@ module Sequent
                   :number_of_replay_processes,
                   :database_config_directory,
                   :event_store_schema_name
+
+    attr_accessor :strict_check_attributes_on_apply_events
 
     attr_reader :migrations_class_name,
                 :versions_table_name,
@@ -101,6 +106,7 @@ module Sequent
       self.offline_replay_persistor_class = DEFAULT_OFFLINE_REPLAY_PERSISTOR_CLASS
       self.online_replay_persistor_class = DEFAULT_ONLINE_REPLAY_PERSISTOR_CLASS
       self.database_config_directory = DEFAULT_DATABASE_CONFIG_DIRECTORY
+      self.strict_check_attributes_on_apply_events = DEFAULT_STRICT_CHECK_ATTRIBUTES_ON_APPLY_EVENTS
 
       self.logger = Logger.new(STDOUT).tap {|l| l.level = Logger::INFO }
     end

--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -19,7 +19,7 @@ module Sequent
       include ActiveModel::Validations::Callbacks
       include Sequent::Core::Helpers::TypeConversionSupport
 
-      attrs created_at: DateTime
+      attrs aggregate_id: String, created_at: DateTime
 
       def initialize(args = {})
         update_all_attributes args

--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -19,7 +19,7 @@ module Sequent
       include ActiveModel::Validations::Callbacks
       include Sequent::Core::Helpers::TypeConversionSupport
 
-      attrs aggregate_id: String, created_at: DateTime
+      attrs created_at: DateTime
 
       def initialize(args = {})
         update_all_attributes args

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require_relative 'sequent_oj'
+require_relative '../application_record.rb'
 
 module Sequent
   module Core

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -161,7 +161,7 @@ EOS
         end
 
         def ensure_known_attributes(attrs)
-          unknowns = attrs.keys.map(&:to_s) - self.attributes.keys.map(&:to_s) - %w[aggregate_id sequence_number user_id event_aggregate_id event_sequence_number]
+          unknowns = attrs.keys.map(&:to_s) - self.class.types.keys.map(&:to_s)
           raise UnknownAttributeError.new("#{self.class.name} does not specify attrs: #{unknowns.join(", ")}") if unknowns.any?
         end
       end

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -161,6 +161,8 @@ EOS
         end
 
         def ensure_known_attributes(attrs)
+          return unless Sequent.configuration.strict_check_attributes_on_apply_events
+
           unknowns = attrs.keys.map(&:to_s) - self.class.types.keys.map(&:to_s)
           raise UnknownAttributeError.new("#{self.class.name} does not specify attrs: #{unknowns.join(", ")}") if unknowns.any?
         end

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -20,6 +20,8 @@ module Sequent
       # get this functionality for free.
       #
       module AttributeSupport
+        class UnknownAttributeError < StandardError; end
+
         # module containing class methods to be added
         module ClassMethods
 
@@ -60,6 +62,7 @@ module Sequent
             class_eval <<EOS
               def update_all_attributes(attrs)
                 super if defined?(super)
+                ensure_known_attributes(attrs)
                 #{@types.map { |attribute, _|
               "@#{attribute} = attrs[:#{attribute}]"
             }.join("\n            ")}
@@ -70,6 +73,7 @@ EOS
             class_eval <<EOS
                def update_all_attributes_from_json(attrs)
                  super if defined?(super)
+                 ensure_known_attributes(attrs)
                  #{@types.map { |attribute, type|
               "@#{attribute} = #{type}.deserialize_from_json(attrs['#{attribute}'])"
             }.join("\n           ")}
@@ -157,9 +161,11 @@ EOS
           prefix ? HashWithIndifferentAccess[result.map { |k, v| ["#{prefix}_#{k}", v] }] : result
         end
 
+        def ensure_known_attributes(attrs)
+          unknowns = attrs.keys.map(&:to_s) - self.attributes.keys.map(&:to_s) - ['aggregate_id']
+          raise UnknownAttributeError.new("#{self.class.name} does not specify attrs: #{unknowns.join(", ")}") if unknowns.any?
+        end
       end
-
-
     end
   end
 end

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -73,7 +73,6 @@ EOS
             class_eval <<EOS
                def update_all_attributes_from_json(attrs)
                  super if defined?(super)
-                 ensure_known_attributes(attrs)
                  #{@types.map { |attribute, type|
               "@#{attribute} = #{type}.deserialize_from_json(attrs['#{attribute}'])"
             }.join("\n           ")}
@@ -162,7 +161,7 @@ EOS
         end
 
         def ensure_known_attributes(attrs)
-          unknowns = attrs.keys.map(&:to_s) - self.attributes.keys.map(&:to_s) - ['aggregate_id']
+          unknowns = attrs.keys.map(&:to_s) - self.attributes.keys.map(&:to_s) - %w[aggregate_id sequence_number user_id event_aggregate_id event_sequence_number]
           raise UnknownAttributeError.new("#{self.class.name} does not specify attrs: #{unknowns.join(", ")}") if unknowns.any?
         end
       end

--- a/spec/fixtures/for_attribute_support.rb
+++ b/spec/fixtures/for_attribute_support.rb
@@ -1,0 +1,21 @@
+class NestedTestClass
+  include Sequent::Core::Helpers::AttributeSupport, ActiveModel::Validations
+  attrs message: String
+  validates_presence_of :message
+end
+
+class AttributeSupportTestClass
+  include Sequent::Core::Helpers::AttributeSupport, ActiveModel::Validations
+  attrs message: String, nested_test_class: NestedTestClass
+  validates_presence_of :message
+  validates_with Sequent::Core::Helpers::AssociationValidator, associations: :nested_test_class
+end
+
+class SubTestClass < NestedTestClass
+  attrs sub_message: String
+  validates_presence_of :sub_message
+end
+
+class SomeEvent < Sequent::Core::Event
+  attrs message: String
+end

--- a/spec/lib/sequent/core/aggregate_root_spec.rb
+++ b/spec/lib/sequent/core/aggregate_root_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Sequent::Core::AggregateRoot do
 
   class TestEvent < Sequent::Core::Event
-    attrs field: String
+    attrs field: String, organization_id: String
   end
 
   class TestAggregateRoot < Sequent::Core::AggregateRoot

--- a/spec/lib/sequent/core/aggregate_root_spec.rb
+++ b/spec/lib/sequent/core/aggregate_root_spec.rb
@@ -130,4 +130,21 @@ describe Sequent::Core::AggregateRoot do
       expect(subject.uncommitted_events).to have(2).items
     end
   end
+
+  context 'strict_check_attributes_on_apply_events' do
+    require_relative 'fixtures'
+    before do
+      Sequent.configure do |c|
+        c.strict_check_attributes_on_apply_events = true
+      end
+    end
+
+    it 'fails when calling apply with unknown attributes' do
+      subject = PersonAggregate.new('1')
+      subject.clear_events
+      expect {
+        subject.set_name_with_unknown_event_attribute
+      }.to raise_error(Sequent::Core::Helpers::AttributeSupport::UnknownAttributeError)
+    end
+  end
 end

--- a/spec/lib/sequent/core/command_service_spec.rb
+++ b/spec/lib/sequent/core/command_service_spec.rb
@@ -10,7 +10,7 @@ class TestCommandHandler < Sequent::CommandHandler
 
   class NotHandledCommand < Sequent::Core::Command; end
 
-  class WithIntegerCommand < Sequent::Core::BaseCommand
+  class WithIntegerCommand < Sequent::Command
     attrs value: Integer
   end
 
@@ -104,7 +104,7 @@ describe Sequent::Core::CommandService do
     end
 
     it "does not parse values if the command is invalid" do
-      command = TestCommandHandler::WithIntegerCommand.new(value: "A")
+      command = TestCommandHandler::WithIntegerCommand.new(value: "A", aggregate_id: '1')
       expect { command_service.execute_commands(command) }.to raise_error do |e|
         expect(e.errors[:value]).to eq ['is not a number']
       end

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -7,32 +7,32 @@ describe Sequent::Core::Event do
   end
 
   class TestEventEvent < Sequent::Core::Event
-    attrs name: String, date_time: DateTime, owner: Person
+    attrs organization_id: String, name: String, date_time: DateTime, owner: Person
   end
 
   class EventWithDate < Sequent::Core::Event
-    attrs date_of_birth: Date
+    attrs date_of_birth: Date, organization_id: String
   end
 
   class FooType;
   end
   class EventWithUnknownAttributeType < Sequent::Core::Event
-    attrs name: FooType
+    attrs name: FooType, organization_id: String
   end
 
   class EventWithSymbol < Sequent::Core::Event
-    attrs status: Symbol
+    attrs status: Symbol, organization_id: String
   end
 
   class EventWithFloat < Sequent::Core::Event
     attrs latitude: Float, longitude: Float
   end
 
-  it "does not include aggregate_id, sequence_number and organization_id in payload" do
+  it "does not include aggregate_id and sequence_number in payload" do
     expect(
       TestEventEvent.new(
         {aggregate_id: 123, sequence_number: 7, organization_id: "bar", name: "foo"}
-      ).payload).to eq({ name: "foo", date_time: nil, owner: nil })
+      ).payload).to eq({ name: "foo", date_time: nil, owner: nil, organization_id: "bar" })
   end
 
   it "deserializes DateTime using iso8601" do
@@ -75,7 +75,8 @@ describe Sequent::Core::Event do
     event = EventWithUnknownAttributeType.new(
       aggregate_id: '123', organization_id: "bar", sequence_number: 7, name: FooType.new
     )
-    expect { EventWithUnknownAttributeType.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))) }.to raise_exception(NoMethodError)
+    expect { EventWithUnknownAttributeType.deserialize_from_json(Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))) }
+      .to raise_exception(NoMethodError)
   end
 
   it "converts symbols" do

--- a/spec/lib/sequent/core/fixtures.rb
+++ b/spec/lib/sequent/core/fixtures.rb
@@ -16,6 +16,10 @@ class PersonAggregate < Sequent::Core::AggregateRoot
     apply NameSet, first_name: first_name, last_name: last_name
   end
 
+  def set_name_with_unknown_event_attribute
+    apply NameSet, does_not_exist: 'test'
+  end
+
   def set_name_if_changed(first_name, last_name)
     apply_if_changed NameSet, first_name: first_name, last_name: last_name
   end

--- a/spec/lib/sequent/core/helpers/attribute_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/attribute_support_spec.rb
@@ -19,6 +19,15 @@ describe Sequent::Core::Helpers::AttributeSupport do
       attrs sub_message: String
       validates_presence_of :sub_message
     end
+    
+    class TestValueObject < Sequent::Core::ValueObject
+      attrs message: String
+    end
+
+    it "raises on unknown attrs" do
+      expect { TestValueObject.new(message: 'hello', something: 'this should raise', something_else: 'and this') }
+        .to raise_error(Sequent::Core::Helpers::AttributeSupport::UnknownAttributeError, 'TestValueObject does not specify attrs: something, something_else')
+    end
 
     it "returns validation errors as hash" do
       subject = NestedTestClass.new

--- a/spec/lib/sequent/core/helpers/attribute_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/attribute_support_spec.rb
@@ -20,13 +20,15 @@ describe Sequent::Core::Helpers::AttributeSupport do
       validates_presence_of :sub_message
     end
     
-    class TestValueObject < Sequent::Core::ValueObject
+    class SomeEvent < Sequent::Core::Event
       attrs message: String
     end
 
     it "raises on unknown attrs" do
-      expect { TestValueObject.new(message: 'hello', something: 'this should raise', something_else: 'and this') }
-        .to raise_error(Sequent::Core::Helpers::AttributeSupport::UnknownAttributeError, 'TestValueObject does not specify attrs: something, something_else')
+      expect { SomeEvent.new(message: 'hello', something: 'this should raise', something_else: 'and this') }.to raise_error(
+        Sequent::Core::Helpers::AttributeSupport::UnknownAttributeError,
+        'SomeEvent does not specify attrs: something, something_else'
+      )
     end
 
     it "returns validation errors as hash" do

--- a/spec/lib/sequent/core/helpers/param_support_spec.rb
+++ b/spec/lib/sequent/core/helpers/param_support_spec.rb
@@ -15,7 +15,7 @@ describe Sequent::Core::Helpers::ParamSupport do
   end
 
   it "can translate nested objects from and into params" do
-    house = House.new(person: ben)
+    house = House.new(owner: ben)
     expect(House.from_params(house.as_params)).to eq(house)
   end
 

--- a/spec/lib/sequent/core/value_object_spec.rb
+++ b/spec/lib/sequent/core/value_object_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
 class Country < Sequent::Core::ValueObject
-  attrs name: String
+  attrs name: String, code: String
 end
 
 class Address < Sequent::Core::ValueObject
-  attrs street: String, country: Country
+  attrs street: String, country: Country, city: String, postal_code: String
 end
 
 class CountryList < Sequent::Core::ValueObject
@@ -66,7 +66,7 @@ describe Sequent::Core::ValueObject do
 
   it 'is be possible to make params of a value object' do
     address = Address.new({:street => 'Foo 12', country: country})
-    expect(address.as_params).to eq HashWithIndifferentAccess.new(street: 'Foo 12', country: country.as_params)
+    expect(address.as_params).to eq HashWithIndifferentAccess.new(street: 'Foo 12', country: country.as_params, city: nil, postal_code: nil)
   end
 
   it 'should be able to create value objects from params' do

--- a/spec/lib/sequent/core/workflow_spec.rb
+++ b/spec/lib/sequent/core/workflow_spec.rb
@@ -19,7 +19,7 @@ describe Sequent::Core::Workflow do
       execute_commands CreateNotification.new(aggregate_id: e.aggregate_id)
 
       after_commit do
-        execute_commands SendWelcomeEmail.new(email: e.email)
+        execute_commands SendWelcomeEmail.new(aggregate_id: e.aggregate_id, email: e.email)
       end
     end
   end
@@ -34,6 +34,7 @@ describe Sequent::Core::Workflow do
       when_event UserWasRegistered.new(aggregate_id: 'user', sequence_number: 1, email: 'user@example.com')
       then_commands notification_command
     end
+
     then_commands notification_command, email_command
   end
 end

--- a/spec/lib/sequent/core/workflow_spec.rb
+++ b/spec/lib/sequent/core/workflow_spec.rb
@@ -4,13 +4,13 @@ require 'sequent/test/event_handler_helpers'
 describe Sequent::Core::Workflow do
   include Sequent::Test::WorkflowHelpers
 
-  class CreateNotification < Sequent::Core::BaseCommand; end
+  class CreateNotification < Sequent::Command; end
 
   class UserWasRegistered < Sequent::Core::Event
     attrs email: String
   end
 
-  class SendWelcomeEmail < Sequent::Core::BaseCommand
+  class SendWelcomeEmail < Sequent::Command
     attrs email: String
   end
 


### PR DESCRIPTION
Right now unspecified attributes will be silently ignored. This PR raises an error if an unknown attr is passed in.

For example when we have some event:

```rb
class SomeEvent < Sequent::Core::Event
  attrs message: String
end
```

We instantiate it with unknown attributes:
```rb
SomeEvent.new(message: 'hello', something: 'this should raise', something_else: 'and this')
```

It gives us a nice descriptive error:
```rb
Sequent::Core::Helpers::AttributeSupport::UnknownAttributeError:
  SomeEvent does not specify attrs: something, something_else
```

This works on anything that includes `AttributeSupport` like `Command` and `ValueObject`.

Implements #193