### PR TITLE
Add dry run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You can start the documentation locally via:
 ```
 cd docs
 bundle install
-bundle exec jekyll serve
+bundle exec jekyll serve --livereload
 ```
 
 Open [localhost:4000](localhost:4000)

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -56,3 +56,5 @@ docs:
         url: /docs/concepts/event_store.html
       - title: "16. Configuration"
         url: /docs/concepts/configuration.html
+      - title: "17. Advanced topics"
+        url: /docs/concepts/advanced.html

--- a/docs/docs/concepts/advanced.md
+++ b/docs/docs/concepts/advanced.md
@@ -1,0 +1,92 @@
+---
+title: Advanced topics
+---
+
+CQRS and Event Sourcing are every powerful tools
+and enable easy implementation for several complex requirements like: traceability, auditability and what-if scenario's. Sequent already provides out-of-the-box support for these concepts.
+
+## Traceablity and auditability
+
+When Commands are executed, Sequent already stores a reference
+between the Commands and the resulting Events. Sequent also ensures
+that Commands that are executed from Workflows will have a reference
+to the causing Event.
+By doing so Sequent provides a full audit trail for your event stream
+by default.
+
+You can query the audit trail as follows:
+
+From a `Sequent::Core::CommandRecord`
+```ruby
+# From a CommandRecord
+command_record = Sequent::Core::CommandRecord.find(1)
+
+# The EventRecord that 'caused' this Command
+command_record.parent
+
+# Returns the top level Sequent::Core::CommandRecord that 'caused'
+# this CommandRecord.
+command_record.origin
+
+# Returns the EventRecords caused by this command 
+command_record.children
+```
+
+From a `Sequent::Core::EventRecord`
+```ruby
+event_record = Sequent::Core::EventRecord.find(1)
+
+# Returns the Sequent::Core::CommandRecord that 'caused' this Event 
+event_record.parent
+
+# Returns the top level Sequent::Core::CommandRecord that 'caused'
+# this Event. This traverses all the way up.
+# When coming from Sequent < 3.2 this can also
+# be an EventRecord. 
+event_record.origin
+
+# Returns the Sequent::Core::CommandRecord's that were execute because
+# of this event 
+event_record.children
+```
+
+## What if scenarios
+
+Sometimes it can be useful to first check what will happen if a Command
+is executed. Sequent provides a Dry Run option which you can use
+in for instance rake tasks to check what will happen. Workflows and
+Projectors are not actually executed nor are the Commands with
+Events stored in the EventStore. This also implies that
+the dry run will only be recorded "one level" deep: Only the fact
+that a Workflow is executed will be recorded it does not execute
+the actual registered `on` block.
+
+**Important:** Dry run is **not Thread safe** since the Configuration
+is changed and shared among Threads. So if you use this in a live
+environment you will typically need invoke this from a stand-alone process
+like a Rake task.
+{: .notice--danger}
+
+
+Example usage:
+
+```ruby
+result = Sequent.dry_run(send_invoice)
+
+result.print(STDOUT)
+```
+
+This will for instance produce the following output:
+
+```bash
++++++++++++++++++++++++++++++++++++
+Command: SendInvoice resulted in 2 events
+-- Event InvoiceSent was handled by:
+-- Projectors: [InvoiceRecordProjector]
+-- Workflows: []
+
+-- Event InvoiceQueuedForEmail was handled by:
+-- Projectors: [InvoiceRecordProjector]
+-- Workflows: [EmailWorkflow]
++++++++++++++++++++++++++++++++++++
+```

--- a/lib/sequent/sequent.rb
+++ b/lib/sequent/sequent.rb
@@ -64,6 +64,10 @@ module Sequent
     configuration.aggregate_repository
   end
 
+  def self.dry_run(*commands)
+    Sequent::Util::DryRun.these_commands(commands)
+  end
+
   # Shortcut classes for easy usage
   Event = Sequent::Core::Event
   Command = Sequent::Core::Command

--- a/lib/sequent/util/dry_run.rb
+++ b/lib/sequent/util/dry_run.rb
@@ -1,0 +1,191 @@
+require_relative '../test/command_handler_helpers'
+
+module Sequent
+  module Util
+    ##
+    # Dry run provides the ability to inspect what would
+    # happen if the given commands would be executed
+    # without actually committing the results.
+    # You can inspect which commands are executed
+    # and what the resulting events would be
+    # with theSequent::Projector's and Sequent::Workflow's
+    # that would be invoked (without actually invoking them).
+    #
+    # Since the Workflow's are not actually invoked new commands
+    # resulting from this Workflow will of course not be in the result.
+    #
+    # Caution: Since the Sequent Configuration is shared between threads this method
+    # is not Thread safe.
+    #
+    # Example usage:
+    #
+    #   result = Sequent.dry_run(create_foo_command, ping_foo_command)
+    #
+    #   result.print(STDOUT)
+    #
+    module DryRun
+      EventInvokedHandler = Struct.new(:event, :handler)
+
+      ##
+      # Proxies the given EventStore implements commit_events
+      # that instead of publish and store just publishes the events.
+      class EventStoreProxy
+        attr_reader :command_with_events, :event_store
+
+        delegate :load_events_for_aggregates,
+          :load_events,
+          :publish_events,
+          :stream_exists?,
+          to: :event_store
+
+        def initialize(result)
+          @event_store = Sequent::Test::CommandHandlerHelpers::FakeEventStore.new
+          @command_with_events = {}
+          @result = result
+        end
+
+        def commit_events(command, streams_with_events)
+          event_store.commit_events(command, streams_with_events)
+
+          new_events = streams_with_events.flat_map { |_, events| events }
+          @result.published_command_with_events(command, new_events)
+        end
+      end
+
+      ##
+      # Records which Projector's and Workflow's are executed
+      #
+      class RecordingEventPublisher < Sequent::Core::EventPublisher
+        attr_reader :projectors, :workflows
+
+        def initialize(result)
+          @result = result
+        end
+
+        def process_event(event)
+          Sequent.configuration.event_handlers.each do |handler|
+            next unless handler.class.handles_message?(event)
+
+            if handler.is_a?(Sequent::Workflow)
+              @result.invoked_workflow(EventInvokedHandler.new(event, handler.class))
+            elsif handler.is_a?(Sequent::Projector)
+              @result.invoked_projector(EventInvokedHandler.new(event, handler.class))
+            else
+              fail "Unrecognized event_handler #{handler.class} called for event #{event.class}"
+            end
+          rescue
+            raise PublishEventError.new(handler.class, event)
+          end
+        end
+      end
+
+      ##
+      # Contains the result of a dry run.
+      #
+      # @see #tree
+      # @see #print
+      #
+      class Result
+        EventCalledHandlers = Struct.new(:event, :projectors, :workflows)
+
+        def initialize
+          @command_with_events = {}
+          @event_invoked_projectors = []
+          @event_invoked_workflows = []
+        end
+
+        def invoked_projector(event_invoked_handler)
+          event_invoked_projectors << event_invoked_handler
+        end
+
+        def invoked_workflow(event_invoked_handler)
+          event_invoked_workflows << event_invoked_handler
+        end
+
+        def published_command_with_events(command, events)
+          command_with_events[command] = events
+        end
+
+        ##
+        # Returns the command with events as a tree structure.
+        #
+        # {
+        #   command => [
+        #     EventCalledHandlers,
+        #     EventCalledHandlers,
+        #     EventCalledHandlers,
+        #   ]
+        # }
+        #
+        # The EventCalledHandlers contains an Event with the
+        # lists of `Sequent::Projector`s and `Sequent::Workflow`s
+        # that were called.
+        #
+        def tree
+          command_with_events.reduce({}) do |memo, (command, events)|
+            events_to_handlers = events.map do |event|
+              for_current_event = ->(pair) { pair.event == event }
+              EventCalledHandlers.new(
+                event,
+                event_invoked_projectors.select(&for_current_event).map(&:handler),
+                event_invoked_workflows.select(&for_current_event).map(&:handler),
+              )
+            end
+            memo[command] = events_to_handlers
+            memo
+          end
+        end
+
+        ##
+        # Prints the output from #tree to the given `io`
+        #
+        def print(io)
+          tree.each_with_index do |(command, event_called_handlerss), index|
+            io.puts "+++++++++++++++++++++++++++++++++++" if index == 0
+            io.puts "Command: #{command.class} resulted in #{event_called_handlerss.length} events"
+            event_called_handlerss.each_with_index do |event_called_handlers, i|
+              io.puts "" if i > 0
+              io.puts "-- Event #{event_called_handlers.event.class} was handled by:"
+              io.puts "-- Projectors: [#{event_called_handlers.projectors.join(', ')}]"
+              io.puts "-- Workflows: [#{event_called_handlers.workflows.join(', ')}]"
+            end
+
+            io.puts "+++++++++++++++++++++++++++++++++++"
+          end
+        end
+
+        private
+
+        attr_reader :command_with_events, :event_invoked_projectors, :event_invoked_workflows
+      end
+
+      ##
+      # Main method of the DryRun.
+      #
+      # Caution: Since the Sequent Configuration is changed and is shared between threads this method
+      # is not Thread safe.
+      #
+      # After invocation the sequent configuration is reset to the state it was before
+      # invoking this method.
+      #
+      # @param commands - the commands to dry run
+      # @return Result - the Result of the dry run. See Result.
+      #
+      def self.these_commands(commands)
+        current_event_store = Sequent.configuration.event_store
+        current_event_publisher = Sequent.configuration.event_publisher
+        result = Result.new
+
+        Sequent.configuration.event_store = EventStoreProxy.new(result)
+        Sequent.configuration.event_publisher = RecordingEventPublisher.new(result)
+
+        Sequent.command_service.execute_commands(*commands)
+
+        result
+      ensure
+        Sequent.configuration.event_store = current_event_store
+        Sequent.configuration.event_publisher = current_event_publisher
+      end
+    end
+  end
+end

--- a/lib/sequent/util/util.rb
+++ b/lib/sequent/util/util.rb
@@ -1,3 +1,4 @@
 require_relative 'skip_if_already_processing'
 require_relative 'timer'
 require_relative 'printer'
+require_relative 'dry_run'

--- a/spec/lib/sequent/util/dry_run_spec.rb
+++ b/spec/lib/sequent/util/dry_run_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe 'dry run' do
+  context 'records the commands and events' do
+    let(:command_handler) do
+      Class.new(Sequent::CommandHandler) do
+        on Sequent::Fixtures::CreateTestAggregate do |command|
+          pong = Sequent::Fixtures::TestAggregateRoot.new(command.aggregate_id)
+          Sequent
+            .aggregate_repository
+            .add_aggregate(
+              pong
+            )
+          pong.ping('foo')
+        end
+
+        on Sequent::Fixtures::PingTestAggregate do |command|
+          aggregate = Sequent.aggregate_repository.load_aggregate(command.aggregate_id)
+          aggregate.ping(command.message)
+        end
+      end
+    end
+
+    let(:workflow) do
+      Class.new(Sequent::Workflow) do
+        on Sequent::Fixtures::TestAggregateCreated do
+          fail 'should not reach this'
+        end
+      end
+    end
+
+    let(:projector) do
+      Class.new(Sequent::Projector) do
+        manages_tables AccountRecord
+
+        on Sequent::Fixtures::TestAggregateCreated do
+          fail 'should not reach this'
+        end
+
+        on Sequent::Fixtures::TestAggregatePinged do
+          fail 'should not reach this'
+        end
+      end
+    end
+
+    let(:projector_2) do
+      Class.new(Sequent::Projector) do
+        manages_tables MessageRecord
+
+        on Sequent::Fixtures::TestAggregateCreated do
+          fail 'should not reach this'
+        end
+      end
+    end
+
+    before :each do
+      Sequent.configure do |config|
+        config.command_handlers = [
+          command_handler.new
+        ]
+        config.event_handlers = [
+          projector.new,
+          projector_2.new,
+          workflow.new,
+        ]
+      end
+    end
+
+    let(:create_test_aggregate) {
+      Sequent::Fixtures::CreateTestAggregate.new(
+        aggregate_id: Sequent.new_uuid,
+      )
+    }
+
+    it 'records consequences of a specific command' do
+      result = Sequent.dry_run(create_test_aggregate)
+
+      expect(result.tree.keys).to eq [create_test_aggregate]
+      expect(result.tree[create_test_aggregate]).to have(2).items
+      expect(result.tree[create_test_aggregate][0].event).to be_a(Sequent::Fixtures::TestAggregateCreated)
+      expect(result.tree[create_test_aggregate][0].projectors).to eq([projector, projector_2])
+      expect(result.tree[create_test_aggregate][0].workflows).to eq([workflow])
+
+      expect(result.tree[create_test_aggregate][1].event).to be_a(Sequent::Fixtures::TestAggregatePinged)
+      expect(result.tree[create_test_aggregate][1].projectors).to eq([projector])
+      expect(result.tree[create_test_aggregate][1].workflows).to be_empty
+    end
+
+    context 'multiple commands' do
+      let(:ping_command) {
+        Sequent::Fixtures::PingTestAggregate.new(
+          aggregate_id: create_test_aggregate.aggregate_id,
+          message: 'pong ping'
+        )
+      }
+
+      it 'records consequences of all commands' do
+        result = Sequent.dry_run(create_test_aggregate, ping_command)
+
+        expect(result.tree.keys).to eq [create_test_aggregate, ping_command]
+        expect(result.tree[ping_command]).to have(1).item
+        expect(result.tree[ping_command][0].event).to be_a(Sequent::Fixtures::TestAggregatePinged)
+        expect(result.tree[ping_command][0].event.message).to eq 'pong ping'
+        expect(result.tree[ping_command][0].projectors).to eq([projector])
+        expect(result.tree[ping_command][0].workflows).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
When using dry run the given commands and resulting events are not stored
but recorded for inspection purposes.
It will also record which Projectors and Workflows would have been invoked
as a result of the Events applied.
Due to the fact that the Sequent.configuration is a singleton and shared
among Threads dry run is not Thread safe.