### PR TITLE
Avoid using RSpec globals

### DIFF
--- a/lib/sequent/generator/template_project/spec/app/projectors/post_projector_spec.rb
+++ b/lib/sequent/generator/template_project/spec/app/projectors/post_projector_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative '../../../app/projectors/post_projector'
 
-describe PostProjector do
+RSpec.describe PostProjector do
   let(:aggregate_id) { Sequent.new_uuid }
   let(:post_projector) { PostProjector.new }
   let(:post_added) { PostAdded.new(aggregate_id: aggregate_id, sequence_number: 1) }

--- a/lib/sequent/generator/template_project/spec/lib/post/post_command_handler_spec.rb
+++ b/lib/sequent/generator/template_project/spec/lib/post/post_command_handler_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 require_relative '../../../lib/post'
 
-describe PostCommandHandler do
+RSpec.describe PostCommandHandler do
   let(:aggregate_id) { Sequent.new_uuid }
 
   before :each do


### PR DESCRIPTION
The general suggestion with RSpec is to configure it with `config.disable_monkey_patching!` which means the `describe` method isn't in the global namespace. This works with or without that setting enabled.