### PR TITLE
Remove unnecessary require_relative

### DIFF
--- a/lib/sequent/generator/template_project/spec/app/projectors/post_projector_spec.rb
+++ b/lib/sequent/generator/template_project/spec/app/projectors/post_projector_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require 'spec_helper'
 require_relative '../../../app/projectors/post_projector'
 
 describe PostProjector do

--- a/lib/sequent/generator/template_project/spec/lib/post/post_command_handler_spec.rb
+++ b/lib/sequent/generator/template_project/spec/lib/post/post_command_handler_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../../spec_helper'
+require 'spec_helper'
 require_relative '../../../lib/post'
 
 describe PostCommandHandler do


### PR DESCRIPTION
RSpec automatically loads the `spec` directory into the load paths.

`require_relative`ing the spec_helper isn't necessary as you can just require it.