### PR TITLE
Fix AR versions in gemspec

### DIFF
--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     'https://github.com/zilverline/sequent'
   s.license       = 'MIT'
 
-  active_star_version = ENV['ACTIVE_STAR_VERSION'] || ['>= 5.0', '<= 6.0']
+  active_star_version = ENV['ACTIVE_STAR_VERSION'] || ['>= 5.0', '< 6.1']
 
   s.add_dependency              'activerecord', active_star_version
   s.add_dependency              'activemodel', active_star_version


### PR DESCRIPTION
We actually meant all 6.0.x releases. Fixes https://github.com/zilverline/sequent/issues/227