### PR TITLE
Relax `parser` version requirement

### DIFF
--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'thread_safe', '~> 0.3.6'
   s.add_dependency              'parallel', '~> 1.17'
   s.add_dependency              'bcrypt', '~> 3.1'
-  s.add_dependency              'parser', '~> 2.6.5'
+  s.add_dependency              'parser', '>= 2.6.5', '< 3'
   s.add_dependency              'i18n'
   s.add_development_dependency  'rspec', '~> 3.8'
   s.add_development_dependency  'timecop', '~> 0.9'


### PR DESCRIPTION
**The issue**
When moving to sequent `3.4.0` (https://github.com/zilverline/sequent/commit/8094b3c39ec5869d2a11e93109f8f3f70dc4a492) I noticed sequent fixed `parser`'s version to `2.6.x`. Previously it required `~> 2.5` which would be more permissive to any version below `3`.

This means the gem cannot be installed along with other dependencies that require sequent `2.7`, I'm wondering if we could relax the dependency requirements to minimum 2.6.5 but still allow newer minor versions, or if there is any reason why sequent might not work with newer minor versions?

**How to reproduce**
Noticed this conflict with the latest version of rubocop, you can reproduce it by trying to install both gems:
```
# Gemfile
source "https://rubygems.org"
gem "rubocop", "0.84.0"
gem "sequent", "3.5.0"

$ bundle install
Fetching gem metadata from https://rubygems.org/...............
Resolving dependencies...
Bundler could not find compatible versions for gem "parser":
  In Gemfile:
    rubocop (= 0.84.0) was resolved to 0.84.0, which depends on
      parser (>= 2.7.0.1)

    sequent (= 3.5.0) was resolved to 3.5.0, which depends on
      parser (~> 2.6.5)
```