### PR TITLE
Synchronise time precision settings throughout sequent

### DIFF
--- a/lib/sequent/core/helpers/equal_support.rb
+++ b/lib/sequent/core/helpers/equal_support.rb
@@ -14,8 +14,8 @@ module Sequent
             self_value = self.send(name)
             other_value = other.send(name)
             if self_value.class == DateTime && other_value.class == DateTime
-              # we don't care about milliseconds. If you know a better way of checking for equality please improve.
-              return false unless (self_value.iso8601 == other_value.iso8601)
+              # Compare using time precision defined.
+              return false unless (self_value.iso8601(ActiveSupport::JSON::Encoding.time_precision) == other_value.iso8601(ActiveSupport::JSON::Encoding.time_precision))
             else
               return false unless (self_value == other_value)
             end

--- a/lib/sequent/core/helpers/param_support.rb
+++ b/lib/sequent/core/helpers/param_support.rb
@@ -76,7 +76,7 @@ module Sequent
           if val.is_a?(Sequent::Core::ValueObject)
             val.as_params
           elsif val.is_a? DateTime
-            val.iso8601
+            val.iso8601(ActiveSupport::JSON::Encoding.time_precision) # this is in sync with Oj `mode: :rails`
           elsif val.is_a? Date
             val.iso8601
           else

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -46,7 +46,7 @@ describe Sequent::Core::Event do
 
   it "events are equal when deserialized from same attributes" do
     event1 = TestEventEvent.new(aggregate_id: "foo", organization_id: "bar", sequence_number: 1)
-    created_at = event1.created_at.iso8601
+    created_at = Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event1.created_at))
     event2 = TestEventEvent.deserialize_from_json("aggregate_id" => "foo", "organization_id" => "bar", "sequence_number" => 1, "created_at" => created_at)
     expect(event1).to eq event2
   end

--- a/spec/lib/sequent/test/time_comparison_spec.rb
+++ b/spec/lib/sequent/test/time_comparison_spec.rb
@@ -9,9 +9,11 @@ end
 
 describe 'Time comparison' do
   around do |example|
+    original_time_zone = Time.zone
     Time.zone = 'UTC'
     example.run
-    Time.zone = nil
+  ensure
+    Time.zone = original_time_zone
   end
 
   time_classes = [Time, DateTime, ActiveSupport::TimeWithZone]
@@ -49,4 +51,5 @@ describe 'Time comparison' do
       expect(Time.current == :test).to be_falsey
     end
   end
+
 end


### PR DESCRIPTION
Use the same time precision when dumping to and parsing from json.

- [ ] needs testing