### PR TITLE
Make implementation contains_aggregate same as load_aggregate

### DIFF
--- a/lib/sequent/core/aggregate_repository.rb
+++ b/lib/sequent/core/aggregate_repository.rb
@@ -100,7 +100,9 @@ module Sequent
       ##
       # Returns whether the event store has an aggregate with the given id
       def contains_aggregate?(aggregate_id)
-        Sequent.configuration.event_store.stream_exists?(aggregate_id)
+        load_aggregate(aggregate_id).present?
+      rescue AggregateNotFound
+        false
       end
 
       # Gets all uncommitted_events from the 'registered' aggregates
@@ -119,7 +121,7 @@ module Sequent
         updated_aggregates = aggregates.values.reject { |x| x.uncommitted_events.empty? }
         return if updated_aggregates.empty?
         streams_with_events = updated_aggregates.map do |aggregate|
-          [ aggregate.event_stream, aggregate.uncommitted_events ]
+          [aggregate.event_stream, aggregate.uncommitted_events]
         end
         updated_aggregates.each(&:clear_events)
         store_events command, streams_with_events

--- a/spec/lib/sequent/core/aggregate_repository_spec.rb
+++ b/spec/lib/sequent/core/aggregate_repository_spec.rb
@@ -38,6 +38,7 @@ describe Sequent::Core::AggregateRepository do
   let(:event_store) { double }
   let(:repository) { Sequent.configuration.aggregate_repository }
   let(:aggregate) { DummyAggregate.new(Sequent.new_uuid) }
+  let(:aggregate_stream_with_events) { [aggregate.event_stream, [:events]] }
 
   it "should track added aggregates by id" do
     allow(event_store).to receive(:load_events_for_aggregates).with([]).and_return([]).once
@@ -136,12 +137,12 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'contains an aggregate' do
-    allow(event_store).to receive(:stream_exists?).with(aggregate.id).and_return(true)
+    allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id]).and_return([aggregate_stream_with_events])
     expect(repository.contains_aggregate?(aggregate.id)).to eq(true)
   end
 
   it 'does not contain an aggregate' do
-    allow(event_store).to receive(:stream_exists?).with(aggregate.id).and_return(false)
+    allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id]).and_raise(Sequent::Core::AggregateRepository::AggregateNotFound.new(aggregate.id))
     expect(repository.contains_aggregate?(aggregate.id)).to eq(false)
   end
 
@@ -167,8 +168,6 @@ describe Sequent::Core::AggregateRepository do
     end
 
     context 'with aggregates in the event store' do
-
-      let(:aggregate_stream_with_events) { [aggregate.event_stream, [:events]] }
 
       let(:aggregate_2) { DummyAggregate.new(Sequent.new_uuid) }
       let(:aggregate_2_stream_with_events) { [aggregate_2.event_stream, [:events_2]] }


### PR DESCRIPTION
In case of gdpr one can choose to delete events from the event store
but keep the eventstreams. This can cause load_aggregate to fail
but contains_aggregate to return true.