### PR TITLE
Exclude SnapshotEvent as parent of a Command

### DIFF
--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -42,7 +42,9 @@ module Sequent
       validates_presence_of :command_type, :command_json
 
       def parent
-        EventRecord.find_by(aggregate_id: event_aggregate_id, sequence_number: event_sequence_number)
+        EventRecord
+          .find_by(aggregate_id: event_aggregate_id, sequence_number: event_sequence_number)
+          .where('event_type != ?', Sequent::Core::SnapshotEvent.name)
       end
 
       def children


### PR DESCRIPTION
SnapshotEvent gets the same sequence_number as the last event, therefor
we need to explicitly exclude them from being a parent of a Command.