### PR TITLE
Quick update on Modelling your Domain Docs 

### DIFF
--- a/docs/docs/modelling-the-domain.md
+++ b/docs/docs/modelling-the-domain.md
@@ -183,7 +183,7 @@ class Usernames < Sequent::AggregateRoot
 end
 ```
 
-We can now obtain the `Usernames` Aggregate by invoking `Usernames.instance`. Next thing we want to do is create a `UserCommandHandler` and add an Author. To ensure everything will work we start by defining our tests.
+We can now obtain the `Usernames` Aggregate by invoking `Usernames.instance`. Next thing we want to do is create a `AuthorCommandHandler` and add an Author. To ensure everything will work we start by defining our tests.
 
 In `spec/lib/author/author_command_handler_spec.rb`
 


### PR DESCRIPTION
I believe the docs is trying to say that the "Next thing we want to do is create a `AuthorCommandHandler`" instead of a `UserCommandHandler`.  It was probably confused with the `Usernames` instance just mentioned on the same paragraph. Please let me know if this fix is correct.