### PR TITLE
Add a new configuration parameter `database_schema_directory`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changes since 3.5
+
+- Added `database_schema_directory` configuration parameter to determine where to
+  find `sequent_schema.rb` and `sequent_migrations.rb`. Currently set to match 
+  `database_config_directory` for backwards compatibility, but with a deparcation 
+  warning.
+
 # Changes since 3.4
 
 - Changed default ruby to latest 2.6 release

--- a/docs/docs/concepts/configuration.md
+++ b/docs/docs/concepts/configuration.md
@@ -119,6 +119,7 @@ For the most recent possibilities please check the `Sequent::Configuration` impl
 |online_replay_persistor_class|The class used to persist the the `Projector`s.|`Sequent::Core::Persistors::ActiveRecordPersistor`|
 |number_of_replay_processes|The [number of process](#number_of_replay_processes) used while offline migration|`4`|
 |database_config_directory|The directory in which db config can be found|`db`|
+|database_schema_directory|The directory in which db schema and migrations can be found|`db`|
 |event_store_schema_name|The name of the db schema in which the [EventStore](event_store.html) is installed|`sequent_schema`|
 |strict_check_attributes_on_apply_events|Whether or not sequent should fail on calling `apply` with invalid attributes.|`false`. Will be enabled by default in the next major release.|
 |migrations_class_name|The name of the [class](#minimum-configuration) containing the migrations|Empty|

--- a/docs/docs/rails-sequent.md
+++ b/docs/docs/rails-sequent.md
@@ -17,9 +17,9 @@ You are already familiar with Ruby on Rails and the core [Concepts](concepts.htm
 
 2. Run `bundle install`
 
-3. Copy the `sequent_schema.rb` file from [https://raw.githubusercontent.com/zilverline/sequent/master/db/sequent_schema.rb](https://raw.githubusercontent.com/zilverline/sequent/master/db/sequent_schema.rb) and put it in your `./config` directory.
+3. Copy the `sequent_schema.rb` file from [https://raw.githubusercontent.com/zilverline/sequent/master/db/sequent_schema.rb](https://raw.githubusercontent.com/zilverline/sequent/master/db/sequent_schema.rb) and put it in your `./db` directory.
 
-4. Create `./config/sequent_migrations.rb`. This will contain your `view_schema` migrations. 
+4. Create `./db/sequent_migrations.rb`. This will contain your `view_schema` migrations. 
     
     ```ruby
     VIEW_SCHEMA_VERSION = 1
@@ -77,7 +77,7 @@ You are already familiar with Ruby on Rails and the core [Concepts](concepts.htm
 7. Add `./config/initializers/sequent.rb` containing at least:
 
     ```ruby
-    require_relative '../sequent_migrations'
+    require_relative '../../db/sequent_migrations'
     
     Sequent.configure do |config|
       config.migrations_class_name = 'SequentMigrations'
@@ -91,6 +91,7 @@ You are already familiar with Ruby on Rails and the core [Concepts](concepts.htm
       ]
 
       config.database_config_directory = 'config'
+      config.database_config_directory = 'db'
       
       # this is the location of your sql files for your view_schema
       config.migration_sql_files_directory = 'db/sequent'

--- a/lib/notices.rb
+++ b/lib/notices.rb
@@ -1,0 +1,16 @@
+# This file is for any notices such as deprecation warnings, which should appear
+# in the logs during app boot. Adding such warnings in other places causes
+# lots of noise with duplicated messages, whereas this file is only
+# run once.
+
+warn <<~TEXT
+
+  [DEPRECATION] In future, the location of `sequent_migrations.rb` and
+  `sequent_schema.rb` will be determined by 
+  `config.database_schema_directory`. 
+
+  Add `config.database_schema_directory = 'config'` (or 
+  whatever location you use currently) to set the location in your 
+  configuration and avoid future errors.
+
+TEXT

--- a/lib/sequent.rb
+++ b/lib/sequent.rb
@@ -3,3 +3,5 @@ require_relative 'sequent/sequent'
 require_relative 'sequent/core/core'
 require_relative 'sequent/util/util'
 require_relative 'sequent/migrations/migrations'
+
+require_relative 'notices'

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -13,6 +13,7 @@ module Sequent
 
     DEFAULT_MIGRATION_SQL_FILES_DIRECTORY = 'db/tables'
     DEFAULT_DATABASE_CONFIG_DIRECTORY = 'db'
+    DEFAULT_DATABASE_SCHEMA_DIRECTORY = 'db'
 
     DEFAULT_VIEW_SCHEMA_NAME = 'view_schema'
     DEFAULT_EVENT_STORE_SCHEMA_NAME= 'sequent_schema'
@@ -61,6 +62,7 @@ module Sequent
                   :online_replay_persistor_class,
                   :number_of_replay_processes,
                   :database_config_directory,
+                  :database_schema_directory,
                   :event_store_schema_name
 
     attr_accessor :strict_check_attributes_on_apply_events
@@ -109,6 +111,9 @@ module Sequent
       self.offline_replay_persistor_class = DEFAULT_OFFLINE_REPLAY_PERSISTOR_CLASS
       self.online_replay_persistor_class = DEFAULT_ONLINE_REPLAY_PERSISTOR_CLASS
       self.database_config_directory = DEFAULT_DATABASE_CONFIG_DIRECTORY
+      # For backwards compatibility, this is currently set to whatever it previously was.
+      # In the next release, this will change to its own default.
+      self.database_schema_directory = self.database_config_directory
       self.strict_check_attributes_on_apply_events = DEFAULT_STRICT_CHECK_ATTRIBUTES_ON_APPLY_EVENTS
 
       self.logger = Logger.new(STDOUT).tap {|l| l.level = Logger::INFO }

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -55,7 +55,7 @@ module Sequent
 
             def create_event_store(db_config)
               event_store_schema = Sequent.configuration.event_store_schema_name
-              sequent_schema = File.join(Sequent.configuration.database_config_directory, "#{event_store_schema}.rb")
+              sequent_schema = File.join(Sequent.configuration.database_schema_directory, "#{event_store_schema}.rb")
               fail "File #{sequent_schema} does not exist. Check your Sequent configuration." unless File.exists?(sequent_schema)
 
               Sequent::Support::Database.establish_connection(db_config)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Sequent
-  VERSION = '3.5.0'
+  VERSION = '3.6.0'
 end


### PR DESCRIPTION
This allows the database schema and migration files to be stored in a separate place from the database config files.

This is helpful when embedding Sequent in Ruby on Rails, where the standard approach is for database config to be in `/config` and database schemas and migrations to be in `/db`.