### PR TITLE
Fix re-entry of process_commands in after_commit hook

### DIFF
--- a/lib/sequent/core/command_service.rb
+++ b/lib/sequent/core/command_service.rb
@@ -52,6 +52,7 @@ module Sequent
               while(!command_queue.empty?) do
                 process_command(command_queue.pop)
               end
+              Sequent::Util.done_processing(:command_service_process_commands)
             end
           ensure
             command_queue.clear

--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -7,7 +7,9 @@ module Sequent
           Sequent::ApplicationRecord.transaction(requires_new: true) do
             yield
           end
-          after_commit_queue.each &:call
+          while(!after_commit_queue.empty?) do
+            after_commit_queue.pop.call
+          end
         ensure
           clear_after_commit_queue
         end
@@ -19,11 +21,11 @@ module Sequent
         private
 
         def after_commit_queue
-          Thread.current[:after_commit_queue] ||= []
+          Thread.current[:after_commit_queue] ||= Queue.new
         end
 
         def clear_after_commit_queue
-          Thread.current[:after_commit_queue] = []
+          after_commit_queue.clear
         end
       end
 

--- a/lib/sequent/util/skip_if_already_processing.rb
+++ b/lib/sequent/util/skip_if_already_processing.rb
@@ -1,15 +1,29 @@
 module Sequent
   module Util
-    def self.skip_if_already_processing(already_processing_key, &block)
-      return if Thread.current[already_processing_key]
+    ##
+    # Returns if the current Thread is already processing work
+    # given the +processing_key+ otherwise
+    # it yields the given +&block+.
+    #
+    # Useful in a Queue and Processing strategy
+    def self.skip_if_already_processing(processing_key, &block)
+      return if Thread.current[processing_key]
 
       begin
-        Thread.current[already_processing_key] = true
+        Thread.current[processing_key] = true
 
-        block.yield
+        yield
       ensure
-        Thread.current[already_processing_key] = nil
+        Thread.current[processing_key] = nil
       end
+    end
+
+    ##
+    # Reset the given +processing_key+ for the current Thread.
+    #
+    # Usefull to make a block protected by +skip_if_already_processing+ reentrant.
+    def self.done_processing(processing_key)
+      Thread.current[processing_key] = nil
     end
   end
 end

--- a/spec/lib/sequent/core/workflow_spec.rb
+++ b/spec/lib/sequent/core/workflow_spec.rb
@@ -2,39 +2,79 @@ require 'spec_helper'
 require 'sequent/test/event_handler_helpers'
 
 describe Sequent::Core::Workflow do
-  include Sequent::Test::WorkflowHelpers
+  class RegisterUser < Sequent::Command; end
+
+  class SendWelcomeEmail < Sequent::Command; end
 
   class CreateNotification < Sequent::Command; end
 
-  class UserWasRegistered < Sequent::Core::Event
-    attrs email: String
+  class UserWasRegistered < Sequent::Core::Event; end
+
+  class WelcomeEmailWasSent < Sequent::Core::Event; end
+
+  class User < Sequent::AggregateRoot
+    def initialize(id)
+      super
+      apply UserWasRegistered
+    end
+
+    def welcome_email_send
+      apply WelcomeEmailWasSent
+    end
   end
 
-  class SendWelcomeEmail < Sequent::Command
-    attrs email: String
+
+  class RegistrationCommandHandler < Sequent::CommandHandler
+    class << self
+      attr_accessor :commands
+
+      def clear_commands
+        self.commands = []
+      end
+    end
+
+    on RegisterUser do |command|
+      Sequent.aggregate_repository.add_aggregate(User.new(command.aggregate_id))
+    end
+    on CreateNotification do |command|
+      self.class.commands << command
+    end
+    on SendWelcomeEmail do |command|
+      self.class.commands << command
+      user = Sequent.aggregate_repository.load_aggregate(command.aggregate_id)
+      user.welcome_email_send
+    end
   end
 
-  class RegistrationWorkflow < Sequent::Core::Workflow
+  class RegistrationWorkflow < Sequent::Workflow
     on UserWasRegistered do |e|
       execute_commands CreateNotification.new(aggregate_id: e.aggregate_id)
 
       after_commit do
-        execute_commands SendWelcomeEmail.new(aggregate_id: e.aggregate_id, email: e.email)
+        execute_commands SendWelcomeEmail.new(aggregate_id: e.aggregate_id)
+      end
+    end
+
+    on WelcomeEmailWasSent do |e|
+      after_commit do
+        execute_commands CreateNotification.new(aggregate_id: e.aggregate_id)
       end
     end
   end
 
-  let(:workflow) { RegistrationWorkflow.new }
+  before do
+    RegistrationCommandHandler.clear_commands
+    Sequent.configuration.command_handlers = [RegistrationCommandHandler.new]
+    Sequent.configuration.event_handlers = [RegistrationWorkflow.new]
+  end
 
-  let(:notification_command) { CreateNotification.new(aggregate_id: 'user') }
-  let(:email_command) { SendWelcomeEmail.new(aggregate_id: 'user', email: 'user@example.com') }
-
-  it 'executes commands' do
-    fake_transaction_provider.transactional do
-      when_event UserWasRegistered.new(aggregate_id: 'user', sequence_number: 1, email: 'user@example.com')
-      then_commands notification_command
-    end
-
-    then_commands notification_command, email_command
+  it 'executes commands registered with after_commit' do
+    Sequent.command_service.execute_commands RegisterUser.new(aggregate_id: Sequent.new_uuid)
+    expect(RegistrationCommandHandler.commands).to have(3).items
+    expect(RegistrationCommandHandler.commands.map(&:class)).to eq [
+      CreateNotification,
+      SendWelcomeEmail,
+      CreateNotification
+    ]
   end
 end


### PR DESCRIPTION
Reset the re-entry lock after command queue is empty
so when the after_commit queue executes another
command the process command is re-entrant again.
Also make sure that after_commit is a queue and
and the registered blocks are popped otherwise
they will be executed on each new commit.

Fixes #246 