### PR TITLE
split creating indexes from creating tables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_script:
   - psql -c 'CREATE DATABASE sequent_spec_db OWNER sequent;' -U postgres
   - bundle exec rake db:create
 script:
-  - RUBYOPTS="-W0" bundle exec rspec
+  - RUBYOPT="-W0" bundle exec rspec

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency              'bcrypt', '~> 3.1'
   s.add_dependency              'parser', '>= 2.6.5', '< 3'
   s.add_dependency              'i18n'
+  s.add_dependency              'tzinfo', '<= 1.2.7'
   s.add_development_dependency  'rspec', rspec_version
   s.add_development_dependency  'timecop', '~> 0.9'
   s.add_development_dependency  'rspec-mocks', rspec_version

--- a/spec/fixtures/db/1/item_records.sql
+++ b/spec/fixtures/db/1/item_records.sql
@@ -4,4 +4,4 @@ CREATE TABLE item_records%SUFFIX% (
     CONSTRAINT item_records_pkey%SUFFIX% PRIMARY KEY (id)
 );
 
-CREATE INDEX unique_aggregate_id%SUFFIX% ON item_records%SUFFIX% USING btree (aggregate_id);
+CREATE INDEX aggregate_id%SUFFIX% ON item_records%SUFFIX% USING btree (aggregate_id);

--- a/spec/fixtures/db/1/line_item_records.sql
+++ b/spec/fixtures/db/1/line_item_records.sql
@@ -4,4 +4,4 @@ CREATE TABLE line_item_records%SUFFIX% (
     CONSTRAINT line_item_records_pkey%SUFFIX% PRIMARY KEY (id)
 );
 
-CREATE INDEX unique_aggregate_id%SUFFIX% ON line_item_records%SUFFIX% USING btree (item_aggregate_id);
+CREATE INDEX aggregate_id%SUFFIX% ON line_item_records%SUFFIX% USING btree (item_aggregate_id);

--- a/spec/fixtures/db/1/message_records.indexes.sql
+++ b/spec/fixtures/db/1/message_records.indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX message_records_message%SUFFIX%
+    ON message_records%SUFFIX% USING btree (message);

--- a/spec/lib/sequent/core/persistors/active_record_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/active_record_persistor_spec.rb
@@ -17,7 +17,10 @@ describe Sequent::Core::Persistors::ActiveRecordPersistor do
     Sequent::Support::Database.create!(db_config)
     ActiveRecord::Base.establish_connection(db_config)
   end
-  after { Sequent::Support::Database.drop!(db_config) }
+  after do
+    Sequent::Support::Database.drop!(db_config)
+    Sequent::Support::Database.disconnect!
+  end
 
   let(:database) { Sequent::Support::Database.new }
 

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -221,7 +221,10 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
       Sequent::Support::Database.establish_connection(db_config)
     end
 
-    after { Sequent::Support::Database.drop!(db_config) }
+    after do
+      Sequent::Support::Database.drop!(db_config)
+      Sequent::Support::Database.disconnect!
+    end
 
     before :each do
       File.open(File.expand_path("1_test_migration.rb", migrations_path), 'w') do |f|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,11 +11,10 @@ require 'simplecov'
 SimpleCov.start if ENV["COVERAGE"]
 
 require_relative 'database'
-Database.establish_connection
-Sequent::ApplicationRecord.connection.execute("TRUNCATE command_records, stream_records CASCADE")
-
 RSpec.configure do |c|
   c.before do
+    Database.establish_connection
+    Sequent::ApplicationRecord.connection.execute("TRUNCATE command_records, stream_records CASCADE")
     Sequent::Configuration.reset
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,22 @@ RSpec::Matchers.define :have_view_schema_table do |expected|
   end
 end
 
+RSpec::Matchers.define :have_view_schema_index do |expected|
+  index_names = []
+  table_name = expected.split('.').first
+
+  match do |connection|
+    index_names = connection
+                    .execute("SELECT tablename || '.' || indexname FROM pg_indexes where tablename = '#{table_name}'")
+                    .flat_map { |r| r.values }
+    expect(index_names).to include(expected)
+  end
+
+  failure_message do |_actual|
+    %Q{expected indexes for table #{table_name}:\n  #{index_names.join("\n  ")}\nto contain:\n  #{expected}}
+  end
+end
+
 RSpec::Matchers.define :have_column do |expected|
   match do |actual|
     actual.reset_column_information


### PR DESCRIPTION
- Split creating indexes from creating tables
- Remove `unique` prefix in index names
