### PR TITLE
Don't use class.descendants to find subclasses

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -42,15 +42,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
-      - name: Install bundler
-        run: |
-          gem install bundler
-      - name: Install ruby dependencies
-        env:
-          ACTIVE_STAR_VERSION: ${{ matrix.active-star-version }}
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4
       - name: Setup database
         run: |
           bundle exec rake db:create

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -38,16 +38,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: Cache bundler
-        uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
+          bundler-cache: true
       - name: Install bundler
         run: |
           gem install bundler

--- a/lib/sequent/core/aggregate_root.rb
+++ b/lib/sequent/core/aggregate_root.rb
@@ -2,6 +2,7 @@ require 'base64'
 require_relative 'helpers/message_handler'
 require_relative 'helpers/autoset_attributes'
 require_relative 'stream_record'
+require_relative 'aggregate_roots'
 
 module Sequent
   module Core
@@ -39,6 +40,10 @@ module Sequent
       include SnapshotConfiguration
 
       attr_reader :id, :uncommitted_events, :sequence_number, :event_stream
+
+      def self.inherited(subclass)
+        AggregateRoots << subclass
+      end
 
       def self.load_from_history(stream, events)
         first, *rest = events

--- a/lib/sequent/core/aggregate_roots.rb
+++ b/lib/sequent/core/aggregate_roots.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Sequent
+  module Core
+    #
+    # Utility class containing all subclasses of AggregateRoot
+    #
+    class AggregateRoots
+      class << self
+        def aggregate_roots
+          @aggregate_roots ||= []
+        end
+
+        def all
+          aggregate_roots
+        end
+
+        def <<(aggregate_root)
+          aggregate_roots << aggregate_root
+        end
+      end
+    end
+  end
+end
+

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -106,7 +106,7 @@ module Sequent
               streams_by_aggregate_id[aggregate_id] =
                 find_event_stream(aggregate_id) ||
                 begin
-                  aggregate_type = FakeEventStore.aggregate_type_for_event(event)
+                  aggregate_type = aggregate_type_for_event(event)
                   raise "cannot find aggregate type associated with creation event #{event}, did you include an event handler in your aggregate for this event?" unless aggregate_type
                   Sequent::Core::EventStream.new(aggregate_type: aggregate_type.name, aggregate_id: aggregate_id)
                 end
@@ -115,10 +115,10 @@ module Sequent
           end
         end
 
-        def self.aggregate_type_for_event(event)
+        def aggregate_type_for_event(event)
           @event_to_aggregate_type ||= ThreadSafe::Cache.new
           @event_to_aggregate_type.fetch_or_store(event.class) do |klass|
-            Sequent::Core::AggregateRoot.descendants.find { |x| x.message_mapping.has_key?(klass) }
+            Sequent::Core::AggregateRoots.all.find { |x| x.message_mapping.has_key?(klass) }
           end
         end
 


### PR DESCRIPTION
This becomes quite slow when running running specs since
the objectspace will grow during test runs.
Use the same approach as Commands to look for descendants
of AggregateRoot.
