### PR TITLE
FIX: enable snapshot setting errors

### DIFF
--- a/lib/sequent/core/aggregate_snapshotter.rb
+++ b/lib/sequent/core/aggregate_snapshotter.rb
@@ -16,7 +16,7 @@ module Sequent
     class AggregateSnapshotter < BaseCommandHandler
 
       on SnapshotCommand do |command|
-        aggregate_ids = repository.event_store.aggregates_that_need_snapshots(@last_aggregate_id, command.limit)
+        aggregate_ids = Sequent.configuration.event_store.aggregates_that_need_snapshots(@last_aggregate_id, command.limit)
         aggregate_ids.each do |aggregate_id|
           take_snapshot!(aggregate_id)
         end

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -106,7 +106,7 @@ module Sequent
             desc 'Rake task that runs before all snapshots rake tasks. Hook applications can use to for instance run other rake tasks.'
             task :init
 
-            task :set_snapshot_threshold, [:aggregate_type,:threshold] => ['sequent:init', :init] do
+            task :set_snapshot_threshold, [:aggregate_type,:threshold] => ['sequent:init', :init] do |_t, args|
               aggregate_type = args['aggregate_type']
               threshold = args['threshold']
 


### PR DESCRIPTION
- Run rake task `sequent:snapshots:set_snapshot_threshold` will get `args` missing
- Run ` Sequent::Core::SnapshotCommand` command will get event_store undefined method error in AggregateSnapshotter