### PR TITLE
Explicitly cast value from_database in optimized replayer

### DIFF
--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -346,10 +346,12 @@ module Sequent
         private
 
         def cast_value_to_column_type(clazz, column_name, record)
-          data = clazz.arel_table.type_cast_for_database(column_name, record[column_name.to_sym])
-          return data unless data.respond_to?(:encoder)
-
-          data.encoder.encode(record[column_name.to_sym])
+          uncasted_value = ActiveModel::Attribute.from_database(
+            column_name,
+            record[column_name.to_sym],
+            Sequent::ApplicationRecord.connection.lookup_cast_type_from_column(@column_cache[clazz.name][column_name]),
+          ).value_for_database
+          Sequent::ApplicationRecord.connection.type_cast(uncasted_value)
         end
       end
     end

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -247,7 +247,7 @@ EOF
 
     context 'csv' do
       let(:insert_csv_size) { 0 }
-      let(:values) { {name: 'ben', initials: ['b'], created_at: DateTime.now} }
+      let(:values) { {name: 'bén', initials: ['björ'], created_at: DateTime.now} }
 
       context 'values as with_indifferent_access' do
         it 'commits a persistor' do


### PR DESCRIPTION
The `data.encoder.encode` was not the solution. This still
returns a non string value and since we use this in csv or
customer prepared statement we need to cast to a string
manually.