### PR TITLE
Allow database config to be set using a postgres connection URL

### DIFF
--- a/spec/lib/sequent/support/database_spec.rb
+++ b/spec/lib/sequent/support/database_spec.rb
@@ -101,6 +101,22 @@ EOF
     end
   end
 
+  describe 'connection options' do
+    let(:db_config) do
+      test_config = Database.test_config
+      # Use test config from all other tests but turn it into an URL. Hardcode
+      # the default port to enforce a proper URL.
+      {
+        "url" => "postgresql://#{test_config['username']}:#{test_config['password']}@#{test_config['host']}:5432/#{test_config['database']}"
+      }
+    end
+
+    it 'connects using an url option' do
+      Sequent::Support::Database.establish_connection(db_config)
+      expect(Sequent::ApplicationRecord.connection).to be_active
+    end
+  end
+
   def database_exists?
     results = Sequent::ApplicationRecord.connection.select_all %Q(
 SELECT 1 FROM pg_database


### PR DESCRIPTION
I prefer to use a `DATABASE_URL` env var to set my database config. Many tooling and hosting environments default to such an URL, including HEROKU and AWS-RDS.

The database config can not always deal with it. Several methods, like `drop!` would flunk as they expect the config to have keys like `database` or `username` and such. 

This patch leverages ActiveRecords API to convert any valid Activerecord config hash into a normalized config hash including keys such as `database` or `username`. Which then can be used anywhere we expect config with certain keys.

It does create a HashWithIndifferentAccess, so normalizing the keys to symbols makes it behave a tad more like one expects (and not accidentally creating a key `"database"` next to a key `:database`), so this patch made that apparent by changing the keys to symbols.

I did not check on older AR versions, AFAIK all supported AR versions have and had this API to normalize the config hash.
I did not run a linter, as I could not find any configured in this project. Please tell me if I violate syntax formatting conventions.

A spec is added to test that a config hash with only an URL can connect to the test database.