### PR TITLE
:bug: private method `resolve_config_for_connection' called

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - ruby-version: 3.0.0
-            active-star-version: '< 6.1.5'
+            active-star-version: '< 7'
           - ruby-version: 3.0.0
             active-star-version: '6.1.4'
           - ruby-version: 3.0.0

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - ruby-version: 3.0.0
-            active-star-version: '< 6.1.5'
+            active-star-version: "'~> 6.1.4', '< 6.1.5'"
           - ruby-version: 3.0.0
             active-star-version: '< 6.0.4'
           - ruby-version: 2.7

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -21,11 +21,13 @@ jobs:
       matrix:
         include:
           - ruby-version: 3.0.0
-            active-star-version: "'~> 6.1.4', '< 6.1.5'"
+            active-star-version: '< 6.1.5'
           - ruby-version: 3.0.0
-            active-star-version: '< 6.0.4'
+            active-star-version: '6.1.4'
+          - ruby-version: 3.0.0
+            active-star-version: '6.1.0'
           - ruby-version: 2.7
-            active-star-version: '< 6.0.3'
+            active-star-version: '6.1.0'
 
     services:
       postgres:
@@ -49,6 +51,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
+          cache-version: ${{ matrix.ruby-version }}-${{ matrix.active-star-version }}
+        env:
+          ACTIVE_STAR_VERSION: ${{ matrix.active-star-version }}
       - name: Setup database
         run: |
           bundle exec rake db:create

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -1,5 +1,7 @@
 require 'active_support/hash_with_indifferent_access'
 
+class ActiveRecordVersionNotSupportedError< StandardError; end
+
 module Sequent
   module Support
     # Offers support operations for a postgres database.
@@ -8,13 +10,11 @@ module Sequent
     # take in a database configuration). Instance methods assume that a database
     # connection yet is established.
     class Database
-      class ActiveRecordNotSupportedError < StandardError; end
 
       attr_reader :db_config
 
       def self.connect!(env)
         db_config = read_config(env)
-        byebug
         establish_connection(db_config)
       end
 
@@ -31,7 +31,7 @@ module Sequent
         elsif ActiveRecord::Base.configurations.respond_to?(:resolve)
           ActiveRecord::Base.configurations.resolve(config).configuration_hash.with_indifferent_access
         else
-          raise ActiveRecordNotSupportedError, "Unsupported ActiveRecord version"
+          raise ActiveRecordVersionNotSupportedError, "Unsupported ActiveRecord version"
         end
       end
 

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
     'https://github.com/zilverline/sequent'
   s.license       = 'MIT'
 
-  active_star_version = ENV['ACTIVE_STAR_VERSION'] || ['>= 5.0', '<= 6.1.4']
+  active_star_version = ENV['ACTIVE_STAR_VERSION'] || ['>= 5.0', '< 7']
 
   rspec_version = '~> 3.10'
 


### PR DESCRIPTION
> - The `resolve_config_for_connection` has been moved to private method in the recent changes
> - And its logic has been changed as well. 


- NoMethodError: private method `resolve_config_for_connection'
called for ActiveRecord::Base:Class

<img width="818" alt="image" src="https://user-images.githubusercontent.com/7600503/133893815-425c3fc9-f461-411f-9550-2c09e598c6ed.png">
