### PR TITLE
:recycle: Using class.name as hash key in Message Handler

### DIFF
--- a/lib/sequent/core/helpers/message_handler.rb
+++ b/lib/sequent/core/helpers/message_handler.rb
@@ -36,8 +36,8 @@ module Sequent
         module ClassMethods
           def on(*message_classes, &block)
             message_classes.each do |message_class|
-              message_mapping[message_class] ||= []
-              message_mapping[message_class] << block
+              message_mapping[message_class.name] ||= []
+              message_mapping[message_class.name] << block
             end
           end
 
@@ -46,7 +46,7 @@ module Sequent
           end
 
           def handles_message?(message)
-            message_mapping.keys.include? message.class
+            message_mapping.keys.include? message.class.name
           end
         end
 
@@ -55,7 +55,7 @@ module Sequent
         end
 
         def handle_message(message)
-          handlers = self.class.message_mapping[message.class]
+          handlers = self.class.message_mapping[message.class.name]
           handlers.each { |handler| self.instance_exec(message, &handler) } if handlers
         end
       end

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -238,7 +238,7 @@ module Sequent
           logger.info "Start replaying events"
 
           time("#{16 ** group_exponent} groups replayed") do
-            event_types = projectors.flat_map { |projector| projector.message_mapping.keys }.uniq.map(&:name)
+            event_types = projectors.flat_map { |projector| projector.message_mapping.keys }.uniq
             disconnect!
 
             number_of_groups = 16 ** group_exponent

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -118,7 +118,7 @@ module Sequent
         def aggregate_type_for_event(event)
           @event_to_aggregate_type ||= ThreadSafe::Cache.new
           @event_to_aggregate_type.fetch_or_store(event.class) do |klass|
-            Sequent::Core::AggregateRoots.all.find { |x| x.message_mapping.has_key?(klass) }
+            Sequent::Core::AggregateRoots.all.find { |x| x.message_mapping.has_key?(klass.name) }
           end
         end
 


### PR DESCRIPTION
https://github.com/zilverline/sequent/issues/278

Fix the issue handles_message? is not matching the given class

<img width="722" alt="image" src="https://user-images.githubusercontent.com/7600503/134097482-7a576a22-3eeb-4b30-a709-7247a5da640d.png">


<img width="851" alt="image" src="https://user-images.githubusercontent.com/7600503/134097466-2fd3cbc9-4a91-4160-ab91-366b2a8c72de.png">
