### PR TITLE
Add spec that asserts optimized postgres persistor keeps on reading

### DIFF
--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -51,6 +51,7 @@ module Sequent
       #   )
       class ReplayOptimizedPostgresPersistor
         include Persistor
+        CHUNK_SIZE = 1024
 
         attr_reader :record_store
         attr_accessor :insert_with_csv_size
@@ -328,7 +329,7 @@ module Sequent
               copy_data = StringIO.new(csv.string)
               conn.transaction do
                 conn.copy_data("COPY #{clazz.table_name} (#{column_names.join(',')}) FROM STDIN WITH csv") do
-                  while (out = copy_data.read(1024))
+                  while (out = copy_data.read(CHUNK_SIZE))
                     conn.put_copy_data(out)
                   end
                 end

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -185,6 +185,19 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
           expect { persistor.commit }.to change { ReplayOptimizedPostgresTest.count }.by(1)
         end
       end
+
+      context 'lots of values' do
+        let(:values) do
+          10_000.times.map do |i|
+            {name: "Ben #{i}", initials: ['b'], created_at: DateTime.now}
+          end
+        end
+
+        it 'commits a persistor' do
+          persistor.create_records(ReplayOptimizedPostgresTest, values)
+          expect { persistor.commit }.to change { ReplayOptimizedPostgresTest.count }.by(10_000)
+        end
+      end
     end
 
     context 'batch inserts' do


### PR DESCRIPTION
This needed a small refactor due to introduction of rubocop
but noticed a spec was missing that asserted the buffer was read
until empty.