### PR TITLE
Add load_until to load_events_for_aggregates

### DIFF
--- a/docs/docs/concepts/aggregate-repository.md
+++ b/docs/docs/concepts/aggregate-repository.md
@@ -46,9 +46,12 @@ Sequent.aggregate_repository.load_aggregate('23456', Invoice)
 
 # or multiple in single call
 Sequent.aggregate_repository.load_aggregate(['65432', '23456'], Invoice)
+
+# load an aggregate up to a certain point in time by adding load_until named parameter
+Sequent.aggregate_repository.load_aggregate(['23456'], Invoice, load_until: Time.now - 1.day)
 ```
 
-The last parameter, the type of AggregateRoot, is optional. If given
+The second parameter, the type of AggregateRoot, is optional. If given
 it will fail if the type of the loaded AggregateRoot differs.
 
 ## Check if AggregateRoots exists

--- a/lib/sequent/core/aggregate_repository.rb
+++ b/lib/sequent/core/aggregate_repository.rb
@@ -80,7 +80,10 @@ module Sequent
         result = aggregates.values_at(*unique_ids).compact
         query_ids = unique_ids - result.map(&:id)
 
-        result += Sequent.configuration.event_store.load_events_for_aggregates(query_ids, load_until: load_until).map do |stream, events|
+        result += Sequent.configuration.event_store.load_events_for_aggregates(
+          query_ids,
+          load_until: load_until,
+        ).map do |stream, events|
           aggregate_class = Class.const_get(stream.aggregate_type)
           aggregate_class.load_from_history(stream, events)
         end

--- a/lib/sequent/core/aggregate_repository.rb
+++ b/lib/sequent/core/aggregate_repository.rb
@@ -70,7 +70,9 @@ module Sequent
       #
       # +aggregate_ids+ The ids of the aggregates to be loaded
       # +clazz+ Optional argument that checks if all aggregates are of type +clazz+
-      def load_aggregates(aggregate_ids, clazz = nil)
+      #
+      # +load_until+ Optional timestamp argument that defines up until which point in time an aggregate should be loaded
+      def load_aggregates(aggregate_ids, clazz = nil, load_until: nil)
         fail ArgumentError, 'aggregate_ids is required' unless aggregate_ids
         return [] if aggregate_ids.empty?
 
@@ -78,7 +80,7 @@ module Sequent
         result = aggregates.values_at(*unique_ids).compact
         query_ids = unique_ids - result.map(&:id)
 
-        result += Sequent.configuration.event_store.load_events_for_aggregates(query_ids).map do |stream, events|
+        result += Sequent.configuration.event_store.load_events_for_aggregates(query_ids, load_until: load_until).map do |stream, events|
           aggregate_class = Class.const_get(stream.aggregate_type)
           aggregate_class.load_from_history(stream, events)
         end

--- a/spec/lib/sequent/core/aggregate_repository_spec.rb
+++ b/spec/lib/sequent/core/aggregate_repository_spec.rb
@@ -194,7 +194,10 @@ describe Sequent::Core::AggregateRepository do
 
     context 'with an empty store' do
       it 'raises an error when nothing is found' do
-        allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id], load_until: nil).and_return([]).once
+        allow(event_store).to receive(:load_events_for_aggregates).with(
+          [aggregate.id],
+          load_until: nil,
+        ).and_return([]).once
 
         expect do
           repository.load_aggregates([aggregate.id])

--- a/spec/lib/sequent/core/aggregate_repository_spec.rb
+++ b/spec/lib/sequent/core/aggregate_repository_spec.rb
@@ -39,14 +39,14 @@ describe Sequent::Core::AggregateRepository do
   let(:aggregate) { DummyAggregate.new(Sequent.new_uuid) }
 
   it 'should track added aggregates by id' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([]).and_return([]).once
+    allow(event_store).to receive(:load_events_for_aggregates).with([], load_until: nil).and_return([]).once
 
     repository.add_aggregate aggregate
     expect(repository.load_aggregate(aggregate.id, DummyAggregate)).to be(aggregate)
   end
 
   it 'should load an aggregate from the event store' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([:id]).and_return(
+    allow(event_store).to receive(:load_events_for_aggregates).with([:id], load_until: nil).and_return(
       [
         [
           aggregate.event_stream,
@@ -62,7 +62,7 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'should not require expected aggregate class' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([:id]).and_return(
+    allow(event_store).to receive(:load_events_for_aggregates).with([:id], load_until: nil).and_return(
       [
         [
           aggregate.event_stream,
@@ -75,7 +75,7 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'should load a subclass aggregate' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([:id]).and_return(
+    allow(event_store).to receive(:load_events_for_aggregates).with([:id], load_until: nil).and_return(
       [
         [
           aggregate.event_stream,
@@ -88,7 +88,7 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'should fail when the expected type does not match the stored type' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([:id]).and_return(
+    allow(event_store).to receive(:load_events_for_aggregates).with([:id], load_until: nil).and_return(
       [
         [
           aggregate.event_stream,
@@ -127,14 +127,14 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'should return aggregates from the identity map after loading from the event store' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id]).and_return(
+    allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id], load_until: nil).and_return(
       [
         [
           aggregate.event_stream, [:events]
         ],
       ],
     ).once
-    allow(event_store).to receive(:load_events_for_aggregates).with([]).and_return([]).once
+    allow(event_store).to receive(:load_events_for_aggregates).with([], load_until: nil).and_return([]).once
 
     a = repository.load_aggregate(aggregate.id, DummyAggregate)
     b = repository.load_aggregate(aggregate.id, DummyAggregate)
@@ -142,7 +142,7 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'should check type when returning aggregate from identity map' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([]).and_return([]).once
+    allow(event_store).to receive(:load_events_for_aggregates).with([], load_until: nil).and_return([]).once
 
     repository.add_aggregate aggregate
     expect { repository.load_aggregate(aggregate.id, String) }.to raise_error { |error|
@@ -158,7 +158,7 @@ describe Sequent::Core::AggregateRepository do
   end
 
   it 'should indicate if a aggregate exists' do
-    allow(event_store).to receive(:load_events_for_aggregates).with([]).and_return([]).once
+    allow(event_store).to receive(:load_events_for_aggregates).with([], load_until: nil).and_return([]).once
 
     repository.add_aggregate aggregate
     expect(repository.ensure_exists(aggregate.id, DummyAggregate)).to be_truthy
@@ -194,7 +194,7 @@ describe Sequent::Core::AggregateRepository do
 
     context 'with an empty store' do
       it 'raises an error when nothing is found' do
-        allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id]).and_return([]).once
+        allow(event_store).to receive(:load_events_for_aggregates).with([aggregate.id], load_until: nil).and_return([]).once
 
         expect do
           repository.load_aggregates([aggregate.id])
@@ -215,7 +215,7 @@ describe Sequent::Core::AggregateRepository do
         allow(event_store)
           .to(
             receive(:load_events_for_aggregates)
-              .with([aggregate.id, aggregate_2.id])
+              .with([aggregate.id, aggregate_2.id], load_until: nil)
               .and_return([aggregate_stream_with_events, aggregate_2_stream_with_events])
               .once,
           )
@@ -233,7 +233,7 @@ describe Sequent::Core::AggregateRepository do
       it 'raises error even if only one aggregate cannot be found' do
         allow(event_store).to(
           receive(:load_events_for_aggregates)
-          .with([aggregate.id, :foo])
+          .with([aggregate.id, :foo], load_until: nil)
           .and_return([aggregate_stream_with_events])
           .once,
         )
@@ -251,7 +251,7 @@ describe Sequent::Core::AggregateRepository do
       it 'can handle duplicate input for load_aggregates' do
         allow(event_store).to(
           receive(:load_events_for_aggregates)
-          .with([aggregate.id])
+          .with([aggregate.id], load_until: nil)
           .and_return([aggregate_stream_with_events])
           .once,
         )
@@ -264,7 +264,7 @@ describe Sequent::Core::AggregateRepository do
         allow(event_store)
           .to(
             receive(:load_events_for_aggregates)
-              .with([aggregate.id])
+              .with([aggregate.id], load_until: nil)
               .and_return([aggregate_stream_with_events])
               .once,
           )
@@ -276,7 +276,7 @@ describe Sequent::Core::AggregateRepository do
         allow(event_store)
           .to(
             receive(:load_events_for_aggregates)
-              .with([aggregate.id, aggregate_3.id])
+              .with([aggregate.id, aggregate_3.id], load_until: nil)
               .and_return([aggregate_stream_with_events, aggregate_3_stream_with_events])
               .once,
           )
@@ -288,7 +288,7 @@ describe Sequent::Core::AggregateRepository do
         allow(event_store)
           .to(
             receive(:load_events_for_aggregates)
-              .with([aggregate.id, aggregate_3.id])
+              .with([aggregate.id, aggregate_3.id], load_until: nil)
               .and_return([aggregate_stream_with_events, aggregate_3_stream_with_events])
               .once,
           )
@@ -306,14 +306,14 @@ describe Sequent::Core::AggregateRepository do
 
       context 'loaded in the identity map' do
         before :each do
-          allow(event_store).to receive(:load_events_for_aggregates).with([]).and_return([]).once
+          allow(event_store).to receive(:load_events_for_aggregates).with([], load_until: nil).and_return([]).once
         end
 
         it 'does not query the event store again' do
           allow(event_store)
             .to(
               receive(:load_events_for_aggregates)
-                .with([aggregate.id, aggregate_2.id])
+                .with([aggregate.id, aggregate_2.id], load_until: nil)
                 .and_return([aggregate_stream_with_events, aggregate_2_stream_with_events])
                 .once,
             )
@@ -329,7 +329,7 @@ describe Sequent::Core::AggregateRepository do
           allow(event_store)
             .to(
               receive(:load_events_for_aggregates)
-                .with([aggregate.id, aggregate_3.id])
+                .with([aggregate.id, aggregate_3.id], load_until: nil)
                 .and_return([aggregate_stream_with_events, aggregate_3_stream_with_events])
                 .once,
             )


### PR DESCRIPTION
In order to load aggregates upon a certain point in time this PR introduces the load_until argument.