### PR TITLE
[feature] define after_initialize callback in sequent command

### DIFF
--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -31,9 +31,13 @@ module Sequent
 
       attrs created_at: DateTime
 
+      define_model_callbacks :initialize, only: :after
+
       def initialize(args = {})
         update_all_attributes args
         @created_at = DateTime.now
+
+        _run_initialize_callbacks
       end
 
       def self.inherited(subclass)

--- a/spec/lib/sequent/core/command_spec.rb
+++ b/spec/lib/sequent/core/command_spec.rb
@@ -17,6 +17,18 @@ describe Sequent::Core::BaseCommand do
       expect { Sequent::Core::Command.new }.to raise_error(/Missing aggregate_id/)
     end
 
+    it "after_initialize works" do
+      class AfterInitCommand < Sequent::Command
+        attrs flag: Boolean
+
+        after_initialize do
+          @flag = true if @flag.nil?
+        end
+      end
+
+      expect(AfterInitCommand.new.flag).to eq true
+    end
+
     context 'validations' do
       class ValidationCommand < Sequent::Command
         attrs flag: Boolean,

--- a/spec/lib/sequent/core/command_spec.rb
+++ b/spec/lib/sequent/core/command_spec.rb
@@ -26,7 +26,8 @@ describe Sequent::Core::BaseCommand do
         end
       end
 
-      expect(AfterInitCommand.new.flag).to eq true
+      cmd = AfterInitCommand.new(aggregate_id: Sequent.new_uuid)
+      expect(cmd.flag).to eq true
     end
 
     context 'validations' do


### PR DESCRIPTION
Define callback `after_initialize` in `Sequent::Command`. We can use this callback to do more things, such as set default value for command attributes.

```ruby
class AfterInitCommand < Sequent::Command
  attrs flag: Boolean

  after_initialize do
    @flag = true if @flag.nil?
  end
end
```
