### PR TITLE
command_record.command producing wrong constant name exception

### DIFF
--- a/lib/sequent/core/command_record.rb
+++ b/lib/sequent/core/command_record.rb
@@ -8,7 +8,7 @@ module Sequent
     module SerializesCommand
       def command
         args = Sequent::Core::Oj.strict_load(command_json)
-        Class.const_get(command_type.to_sym).deserialize_from_json(args)
+        Class.const_get(command_type).deserialize_from_json(args)
       end
 
       def command=(command)

--- a/spec/lib/sequent/core/command_record_spec.rb
+++ b/spec/lib/sequent/core/command_record_spec.rb
@@ -12,7 +12,7 @@ describe Sequent::Core::CommandRecord do
       subject.command = command
     end
 
-    it 'returns the original command command' do
+    it 'returns the original command' do
       expect(subject.command).to eq command
     end
   end

--- a/spec/lib/sequent/core/command_record_spec.rb
+++ b/spec/lib/sequent/core/command_record_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Sequent::Core::CommandRecord do
+  let(:command) { Sequent::Core::Command.new(aggregate_id: 'abc') }
+
+  subject { described_class.new }
+
+  describe '#command' do
+    before do
+      subject.command = command
+    end
+
+    it 'returns the original command command' do
+      expect(subject.command).to eq command
+    end
+  end
+end


### PR DESCRIPTION
There is a bug with `Sequent::Core::CommandRecord.last.command`.
It will fail with `wrong constant name` if you have a class with a namespace, for example: `Foo::Bar`

I believe it happens because Class.const_get should accept string instead of symbol