### PR TITLE
Update aggregate-repository.md docs

### DIFF
--- a/docs/docs/concepts/aggregate-repository.md
+++ b/docs/docs/concepts/aggregate-repository.md
@@ -45,7 +45,7 @@ to ensure the Unit-Of-Work is cleaned using `clear` or `clear!`
 Sequent.aggregate_repository.load_aggregate('23456', Invoice)
 
 # or multiple in single call
-Sequent.aggregate_repository.load_aggregate(['65432', '23456'], Invoice)
+Sequent.aggregate_repository.load_aggregates(['65432', '23456'], Invoice)
 
 # load single AggregateRoot up until a moment in time, skipping possible 
 # snapshotevents


### PR DESCRIPTION
Update docs to use `load_aggregates` instead of `load_aggregate` for loading multiple aggregates in a single call. More info at the following issue: https://github.com/zilverline/sequent/issues/320