### PR TITLE
Introducing: message handler options

### DIFF
--- a/docs/docs/concepts/advanced.md
+++ b/docs/docs/concepts/advanced.md
@@ -210,7 +210,7 @@ For a list of supported built-in message matchers, see: https://www.rubydoc.info
 
 For a list of supported built-in attr matchers, see: https://www.rubydoc.info/gems/sequent/Sequent/Core/Helpers/AttrMatchers.
 
-## Custom message matcher
+### Custom message matcher
 
 You can also provide your own custom message matchers as follows:
 
@@ -242,7 +242,7 @@ class MyWorkfow < Sequent::Workflow
 end
 ```
 
-## Custom attr matcher
+### Custom attr matcher
 
 You can also provide your own custom attr matchers as follows:
 

--- a/docs/docs/concepts/advanced.md
+++ b/docs/docs/concepts/advanced.md
@@ -273,3 +273,27 @@ class MyWorkfow < Sequent::Workflow
   end
 end
 ```
+
+## Message handler load-time options
+
+Since Sequent 5.0, each `Sequent::Core::Helpers::MessageHandler` (`Sequent::AggregateRoot`, `Sequent::Projector`, `Sequent::Workflow` and `Sequent::CommandHandler`) has support for processing load-time options.
+
+This works as follows:
+
+```ruby
+class MyBaseWorkflow < Sequent::Workflow
+  option :deduplicate_on do |matcher, attributes|
+    # This block is called only during initialisation, for each matcher declared in an `on` definition.
+
+    attributes == %i[aggregate_id] # true
+  end
+end
+
+class MyWorkflow < MyBaseWorkflow
+  on MyEvent, deduplicate_on: %i[aggregate_id] do |event|
+    # ...
+  end
+end
+```
+
+Registered options are scoped per class hierarchy, so in the above example, all workflows extending from `MyBaseWorkflow` support the `deduplicate_on` option in `on` definitions. Classes in other hierarchies (like a `Sequent::Projector`) will not have this option (but can register their own options of course).

--- a/lib/sequent/core/helpers/message_handler.rb
+++ b/lib/sequent/core/helpers/message_handler.rb
@@ -51,8 +51,8 @@ module Sequent
             )
 
             message_matchers.each do |matcher|
-              opts.each do |name, values|
-                option_registry.call_option(self, name, matcher, *values)
+              opts.each do |name, value|
+                option_registry.call_option(self, name, matcher, value)
               end
             end
           end

--- a/lib/sequent/core/helpers/message_handler.rb
+++ b/lib/sequent/core/helpers/message_handler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'message_handler_option_registry'
 require_relative 'message_router'
 require_relative 'message_dispatcher'
 
@@ -39,13 +40,25 @@ module Sequent
       #
       module MessageHandler
         module ClassMethods
-          def on(*args, &block)
+          def on(*args, **opts, &block)
             OnArgumentsValidator.validate_arguments!(*args)
 
+            message_matchers = args.map { |arg| MessageMatchers::ArgumentCoercer.coerce_argument(arg) }
+
             message_router.register_matchers(
-              *args.map { |arg| MessageMatchers::ArgumentCoercer.coerce_argument(arg) },
+              *message_matchers,
               block,
             )
+
+            message_matchers.each do |matcher|
+              opts.each do |name, values|
+                option_registry.call_option(self, name, matcher, *values)
+              end
+            end
+          end
+
+          def option(name, &block)
+            option_registry.register_option(name, block)
           end
 
           def message_mapping
@@ -90,6 +103,8 @@ module Sequent
           host_class.extend(ClassMethods)
           host_class.extend(MessageMatchers)
           host_class.extend(AttrMatchers)
+
+          host_class.class_attribute :option_registry, default: MessageHandlerOptionRegistry.new
         end
 
         def handle_message(message)

--- a/lib/sequent/core/helpers/message_handler_option_registry.rb
+++ b/lib/sequent/core/helpers/message_handler_option_registry.rb
@@ -43,7 +43,7 @@ module Sequent
           @entries[name] || fail(
             ArgumentError,
             "Unsupported option: '#{name}'; " \
-            "#{@entries.keys.any? ? "registered options: #{@entries.keys.join(', ')}" : 'no registered options' }",
+            "#{@entries.keys.any? ? "registered options: #{@entries.keys.join(', ')}" : 'no registered options'}",
           )
         end
 

--- a/lib/sequent/core/helpers/message_handler_option_registry.rb
+++ b/lib/sequent/core/helpers/message_handler_option_registry.rb
@@ -7,7 +7,7 @@ module Sequent
         attr_reader :entries
 
         def initialize
-          @entries = {}
+          clear_options
         end
 
         ##
@@ -25,6 +25,13 @@ module Sequent
         def call_option(context, name, *args)
           handler = find_option(name)
           context.instance_exec(*args, &handler)
+        end
+
+        ##
+        # Removes all options from the registry.
+        #
+        def clear_options
+          @entries = {}
         end
 
         private

--- a/lib/sequent/core/helpers/message_handler_option_registry.rb
+++ b/lib/sequent/core/helpers/message_handler_option_registry.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Sequent
+  module Core
+    module Helpers
+      class MessageHandlerOptionRegistry
+        attr_reader :entries
+
+        def initialize
+          @entries = {}
+        end
+
+        ##
+        # Registers a handler for the given option.
+        #
+        def register_option(name, handler)
+          fail ArgumentError, "Option with name '#{name}' already registered" if option_registered?(name)
+
+          @entries[name] = handler
+        end
+
+        ##
+        # Calls the options with the given arguments with `self` bound to the given context.
+        #
+        def call_option(context, name, *args)
+          handler = find_option(name)
+          context.instance_exec(*args, &handler)
+        end
+
+        private
+
+        ##
+        # Returns the handler for given option.
+        #
+        def find_option(name)
+          @entries[name] || fail(
+            ArgumentError,
+            "Unsupported option: '#{name}'; " \
+            "#{@entries.keys.any? ? "registered options: #{@entries.keys.join(', ')}" : 'no registered options' }",
+          )
+        end
+
+        ##
+        # Returns true when an option for the given name is registered, or false otherwise.
+        #
+        def option_registered?(name)
+          @entries.key?(name)
+        end
+      end
+    end
+  end
+end

--- a/lib/sequent/core/helpers/message_router.rb
+++ b/lib/sequent/core/helpers/message_router.rb
@@ -10,7 +10,7 @@ module Sequent
         attr_reader :routes
 
         def initialize
-          @routes = Hash.new { |h, k| h[k] = Set.new }
+          clear_routes
         end
 
         ##
@@ -41,6 +41,13 @@ module Sequent
         #
         def matches_message?(message)
           match_message(message).any?
+        end
+
+        ##
+        # Removes all routes from the router.
+        #
+        def clear_routes
+          @routes = Hash.new { |h, k| h[k] = Set.new }
         end
       end
     end

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -13,7 +13,7 @@ module Sequent
         Workflows << subclass
       end
 
-      def self.on(*message_classes, &block)
+      def self.on(*args, **opts, &block)
         decorated_block = ->(event) do
           begin
             old_event = CurrentEvent.current
@@ -23,7 +23,7 @@ module Sequent
             CurrentEvent.current = old_event
           end
         end
-        super(*message_classes, &decorated_block)
+        super(*args, **opts, &decorated_block)
       end
 
       def execute_commands(*commands)

--- a/spec/lib/sequent/core/helpers/message_handler_option_registry_spec.rb
+++ b/spec/lib/sequent/core/helpers/message_handler_option_registry_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Sequent::Core::Helpers::MessageHandlerOptionRegistry do
+  let(:option_registry) { Sequent::Core::Helpers::MessageHandlerOptionRegistry.new }
+  let(:name) { :my_option }
+  let(:handler) { -> {} }
+
+  describe '#register_option' do
+    subject { option_registry.register_option(name, handler) }
+
+    context 'given no option is registered with the given name' do
+      it 'registers the option' do
+        expect { subject }
+          .to change { option_registry.entries }
+          .from({})
+          .to(name => handler)
+      end
+    end
+
+    context 'given an option is registered with the given name' do
+      before do
+        option_registry.register_option(name, handler)
+      end
+
+      it 'fails' do
+        expect { subject }.to raise_error(ArgumentError, "Option with name '#{name}' already registered")
+      end
+    end
+  end
+
+  describe '#call_option' do
+    let(:context) { self }
+
+    context 'given an option is registered with the given name' do
+      context 'and no argument is passed' do
+        let(:args) { [] }
+
+        it 'calls the registered handler without arguments' do
+          expect do |b|
+            option_registry.register_option(name, b)
+            option_registry.call_option(context, name, *args)
+          end.to yield_with_no_args
+        end
+      end
+
+      context 'and a single argument is passed' do
+        let(:args) { ['arg'] }
+
+        it 'calls the registered handler with a single argument' do
+          expect do |b|
+            option_registry.register_option(name, b)
+            option_registry.call_option(context, name, *args)
+          end.to yield_with_args(*args)
+        end
+      end
+
+      context 'and multiple arguments are passed' do
+        let(:args) { [1, 2] }
+
+        it 'calls the registered handler with all of the arguments' do
+          expect do |b|
+            option_registry.register_option(name, b)
+            option_registry.call_option(context, name, *args)
+          end.to yield_with_args(*args)
+        end
+      end
+    end
+
+    context 'given registered options at all' do
+      let(:args) { [] }
+
+      it 'fails' do
+        expect { option_registry.call_option(context, name, *args) }
+          .to raise_error(ArgumentError, "Unsupported option: '#{name}'; no registered options")
+      end
+    end
+
+    context 'given no option is registered with the given name' do
+      let(:args) { [] }
+
+      before do
+        option_registry.register_option(:other_option, handler)
+      end
+
+      it 'fails' do
+        expect { option_registry.call_option(context, name, *args) }
+          .to raise_error(ArgumentError, "Unsupported option: '#{name}'; registered options: other_option")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example usage:

```ruby
class MyEventHandler
  include Sequent::Core::Helpers::MessageHandler

  option :my_option do |matcher, argument|
    # This block is called only during initialisation, for each matcher declared in an `on` definition.

    argument == :my_value # true
  end

  on MyEvent, my_option: :my_value do |event|
    # ...
  end
end
```

Can be useful for cases like this:

```ruby
module DeduplicableWorkflow
  extend ActiveSupport::Concern

  included do
    option :deduplicate_on do |matcher, attributes|
      # Stick matcher + attributes in some registry somewhere, to be dealt with later.
    end
  end
end

class BaseWorkflow < Sequent::Workflow
  include DeduplicableWorkflow
end

class MyWorkflow < BaseWorkflow
  on MyEvent, deduplicate_on: %i[aggregate_id] do |event|
    # ...
  end  
end
```

Registered options are scoped per class hierarchy, some in the above example, all workflows extending from `BaseWorkflow` support the `deduplicate_on` option in `on` definitions. Classes in other hierarchies (like a `Sequent::Projector`) don't have this option (but can register their own options of course).