### PR TITLE
Rename `matcher_description` to `to_s`

### DIFF
--- a/docs/docs/concepts/advanced.md
+++ b/docs/docs/concepts/advanced.md
@@ -220,7 +220,7 @@ MyMessageMatcher = Struct.new(:expected_argument) do
     # return a truthy value if it matches, or falsey otherwise.
   end
 
-  def matcher_description
+  def to_s
     "my_message_matcher(#{Sequent::Core::Helpers::MessageMatchers::ArgumentSerializer.serialize_value(expected_value)})"
   end
 end
@@ -252,7 +252,7 @@ MyAttrMatcher = Struct.new(:expected_value) do
     # return a truthy value if it matches, or falsey otherwise.
   end
 
-  def matcher_description
+  def to_s
     "my_attr_matcher(#{Sequent::Core::Helpers::AttrMatchers::ArgumentSerializer.serialize_value(expected_value)})"
   end
 end

--- a/lib/sequent/core/helpers/attr_matchers/argument_serializer.rb
+++ b/lib/sequent/core/helpers/attr_matchers/argument_serializer.rb
@@ -7,7 +7,7 @@ module Sequent
         class ArgumentSerializer
           class << self
             def serialize_value(value)
-              return value.matcher_description if value.respond_to?(:matches_attr?)
+              return value.to_s if value.respond_to?(:matches_attr?)
               return %("#{value}") if value.is_a?(String)
 
               value

--- a/lib/sequent/core/helpers/attr_matchers/equals.rb
+++ b/lib/sequent/core/helpers/attr_matchers/equals.rb
@@ -9,7 +9,7 @@ module Sequent
             actual_value == expected_value
           end
 
-          def matcher_description
+          def to_s
             "eq(#{ArgumentSerializer.serialize_value(expected_value)})"
           end
         end

--- a/lib/sequent/core/helpers/attr_matchers/greater_than.rb
+++ b/lib/sequent/core/helpers/attr_matchers/greater_than.rb
@@ -9,7 +9,7 @@ module Sequent
             actual_value > expected_value
           end
 
-          def matcher_description
+          def to_s
             "gt(#{ArgumentSerializer.serialize_value(expected_value)})"
           end
         end

--- a/lib/sequent/core/helpers/attr_matchers/greater_than_equals.rb
+++ b/lib/sequent/core/helpers/attr_matchers/greater_than_equals.rb
@@ -9,7 +9,7 @@ module Sequent
             actual_value >= expected_value
           end
 
-          def matcher_description
+          def to_s
             "gte(#{ArgumentSerializer.serialize_value(expected_value)})"
           end
         end

--- a/lib/sequent/core/helpers/attr_matchers/less_than.rb
+++ b/lib/sequent/core/helpers/attr_matchers/less_than.rb
@@ -9,7 +9,7 @@ module Sequent
             actual_value < expected_value
           end
 
-          def matcher_description
+          def to_s
             "lt(#{ArgumentSerializer.serialize_value(expected_value)})"
           end
         end

--- a/lib/sequent/core/helpers/attr_matchers/less_than_equals.rb
+++ b/lib/sequent/core/helpers/attr_matchers/less_than_equals.rb
@@ -9,7 +9,7 @@ module Sequent
             actual_value <= expected_value
           end
 
-          def matcher_description
+          def to_s
             "lte(#{ArgumentSerializer.serialize_value(expected_value)})"
           end
         end

--- a/lib/sequent/core/helpers/attr_matchers/not_equals.rb
+++ b/lib/sequent/core/helpers/attr_matchers/not_equals.rb
@@ -9,7 +9,7 @@ module Sequent
             actual_value != expected_value
           end
 
-          def matcher_description
+          def to_s
             "neq(#{ArgumentSerializer.serialize_value(expected_value)})"
           end
         end

--- a/lib/sequent/core/helpers/message_matchers/any.rb
+++ b/lib/sequent/core/helpers/message_matchers/any.rb
@@ -13,7 +13,7 @@ module Sequent
             true
           end
 
-          def matcher_description
+          def to_s
             "any#{matcher_arguments}"
           end
 

--- a/lib/sequent/core/helpers/message_matchers/argument_serializer.rb
+++ b/lib/sequent/core/helpers/message_matchers/argument_serializer.rb
@@ -7,7 +7,7 @@ module Sequent
         class ArgumentSerializer
           class << self
             def serialize_value(value)
-              return value.matcher_description if value.respond_to?(:matches_message?)
+              return value.to_s if value.respond_to?(:matches_message?)
               return %("#{value}") if value.is_a?(String)
 
               value

--- a/lib/sequent/core/helpers/message_matchers/has_attrs.rb
+++ b/lib/sequent/core/helpers/message_matchers/has_attrs.rb
@@ -19,7 +19,7 @@ module Sequent
               matches_attrs?(message, expected_attrs)
           end
 
-          def matcher_description
+          def to_s
             "has_attrs(#{ArgumentSerializer.serialize_value(message_matcher)}, #{matcher_arguments})"
           end
 

--- a/lib/sequent/core/helpers/message_matchers/instance_of.rb
+++ b/lib/sequent/core/helpers/message_matchers/instance_of.rb
@@ -9,7 +9,7 @@ module Sequent
             message.instance_of?(expected_class)
           end
 
-          def matcher_description
+          def to_s
             expected_class
           end
         end

--- a/lib/sequent/core/helpers/message_matchers/is_a.rb
+++ b/lib/sequent/core/helpers/message_matchers/is_a.rb
@@ -11,7 +11,7 @@ module Sequent
             message.is_a?(expected_class) unless excluded?(message)
           end
 
-          def matcher_description
+          def to_s
             "is_a(#{matcher_arguments})"
           end
 

--- a/spec/lib/sequent/core/helpers/attr_matchers/equals_spec.rb
+++ b/spec/lib/sequent/core/helpers/attr_matchers/equals_spec.rb
@@ -29,8 +29,8 @@ describe Sequent::Core::Helpers::AttrMatchers::Equals do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher' do
       expect(subject).to eq('eq("foo")')

--- a/spec/lib/sequent/core/helpers/attr_matchers/greater_than_equals_spec.rb
+++ b/spec/lib/sequent/core/helpers/attr_matchers/greater_than_equals_spec.rb
@@ -38,8 +38,8 @@ describe Sequent::Core::Helpers::AttrMatchers::GreaterThanEquals do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher' do
       expect(subject).to eq('gte(1)')

--- a/spec/lib/sequent/core/helpers/attr_matchers/greater_than_spec.rb
+++ b/spec/lib/sequent/core/helpers/attr_matchers/greater_than_spec.rb
@@ -38,8 +38,8 @@ describe Sequent::Core::Helpers::AttrMatchers::GreaterThan do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher' do
       expect(subject).to eq('gt(1)')

--- a/spec/lib/sequent/core/helpers/attr_matchers/less_than_equals_spec.rb
+++ b/spec/lib/sequent/core/helpers/attr_matchers/less_than_equals_spec.rb
@@ -38,8 +38,8 @@ describe Sequent::Core::Helpers::AttrMatchers::LessThanEquals do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher' do
       expect(subject).to eq('lte(1)')

--- a/spec/lib/sequent/core/helpers/attr_matchers/less_than_spec.rb
+++ b/spec/lib/sequent/core/helpers/attr_matchers/less_than_spec.rb
@@ -38,8 +38,8 @@ describe Sequent::Core::Helpers::AttrMatchers::LessThan do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher' do
       expect(subject).to eq('lt(1)')

--- a/spec/lib/sequent/core/helpers/attr_matchers/not_equals_spec.rb
+++ b/spec/lib/sequent/core/helpers/attr_matchers/not_equals_spec.rb
@@ -29,8 +29,8 @@ describe Sequent::Core::Helpers::AttrMatchers::NotEquals do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher' do
       expect(subject).to eq('neq("foo")')

--- a/spec/lib/sequent/core/helpers/message_matchers/any_spec.rb
+++ b/spec/lib/sequent/core/helpers/message_matchers/any_spec.rb
@@ -41,8 +41,8 @@ describe Sequent::Core::Helpers::MessageMatchers::Any do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     context 'given no opts' do
       let(:opts) { {} }

--- a/spec/lib/sequent/core/helpers/message_matchers/has_attrs_spec.rb
+++ b/spec/lib/sequent/core/helpers/message_matchers/has_attrs_spec.rb
@@ -166,8 +166,8 @@ describe Sequent::Core::Helpers::MessageMatchers::HasAttrs do
     end
   end
 
-  describe '#matcher_description' do
-    subject { matcher.matcher_description }
+  describe '#to_s' do
+    subject { matcher.to_s }
 
     it 'returns a description for the matcher including all expected attrs' do
       expect(subject).to eq(%[has_attrs(TestMessage, aggregate_id: "x", sequence_number: 1)])


### PR DESCRIPTION
In order to simplify the interface for message/attr matchers.