### PR TITLE
Improve traceability of PublishEventError

### DIFF
--- a/lib/sequent/core/event_publisher.rb
+++ b/lib/sequent/core/event_publisher.rb
@@ -55,8 +55,10 @@ module Sequent
 
         configuration.event_handlers.each do |handler|
           handler.handle_message event
-        rescue StandardError
-          raise PublishEventError.new(handler.class, event)
+        rescue StandardError => e
+          publish_event_error = PublishEventError.new(handler.class, event)
+          publish_event_error.set_backtrace(e.backtrace)
+          fail publish_event_error
         end
       end
 

--- a/lib/sequent/core/event_publisher.rb
+++ b/lib/sequent/core/event_publisher.rb
@@ -58,7 +58,7 @@ module Sequent
         rescue StandardError => e
           publish_event_error = PublishEventError.new(handler.class, event)
           publish_event_error.set_backtrace(e.backtrace)
-          fail publish_event_error
+          raise publish_event_error
         end
       end
 


### PR DESCRIPTION
Sets the backtrace of PublishEventError to that of the original error to increase traceability.