### PR TITLE
Fix conflict when using Sequent::Test::WorkflowHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Changed the default type of `aggregate_id` in `sequent_schema` to `uuid` since Postgres support this for quite long.
 - Added support for applications using ActiveRecord multiple database connections feature
+**BREAKING CHANGES**: 
+- Renamed file of `Sequent::Test::WorkflowHelpers` to `workflow_helpers`. If you require this file manually you will need to update it's references
+- You now must "tag" specs using `Sequent::Test::WorkflowHelpers` with the following metadata `workflows: true` to avoid collision with other specs
 
 # Changelog 5.0.0 (changes since 4.3.0)
 

--- a/lib/sequent/test.rb
+++ b/lib/sequent/test.rb
@@ -3,4 +3,4 @@
 require_relative 'sequent'
 require_relative 'test/command_handler_helpers'
 require_relative 'test/event_stream_helpers'
-require_relative 'test/event_handler_helpers'
+require_relative 'test/workflow_helpers'

--- a/spec/lib/sequent/core/workflow_spec.rb
+++ b/spec/lib/sequent/core/workflow_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sequent/test/event_handler_helpers'
+require 'sequent/test/workflow_helpers'
 
 describe Sequent::Core::Workflow do
   class RegisterUser < Sequent::Command; end

--- a/spec/lib/sequent/test/test_spec.rb
+++ b/spec/lib/sequent/test/test_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'sequent/test/workflow_helpers'
+
+RSpec.configure do |config|
+  config.include Sequent::Test::CommandHandlerHelpers
+  config.include Sequent::Test::WorkflowHelpers, workflows: true
+end
+
+describe 'Test Helpers' do
+  after do
+    # assert that sequent configuration is correctly reset after tagged group
+    expect(Sequent.command_service.class).to_not eq(Sequent::Test::WorkflowHelpers::FakeCommandService)
+  end
+
+  let(:spec) { double }
+
+  it 'fails then trying to include without WorkflowHelpers without metadata argument workflows' do
+    allow(spec).to receive(:metadata).and_return({})
+
+    expect do
+      Sequent::Test::WorkflowHelpers.included(spec)
+    end.to raise_error(/Missing metadata argument `workflows: true` when including Sequent::Test::WorkflowHelpers/)
+  end
+
+  context Sequent::Test::WorkflowHelpers, workflows: true do
+    it 'uses the FakeCommandService in specs tagged with workflows' do
+      expect(Sequent.command_service.class).to eq(Sequent::Test::WorkflowHelpers::FakeCommandService)
+    end
+  end
+
+  context Sequent::Test::CommandHandlerHelpers do
+    it 'does not conflict with Sequent::Test::WorkflowHelpers' do
+      expect(Sequent.command_service.class).to eq(Sequent::Core::CommandService)
+    end
+  end
+end


### PR DESCRIPTION
Using WorkflowHelpers could potentially and most likely break other specs
running after any spec including WorkflowHelpers. This was due to the fact
this spec altered the Sequent.configuration without restoring its original value.

To ensure this WorkflowHelpers plays nicely with other specs you
must, as of now, include it using `workflows: true` metadata:

```ruby
  RSpec.configure do |config|
    config.include Sequent::Test::WorkflowHelpers, workflows: true
  end
```