### PR TITLE
Provide a proper way of running Rails migrations next to Sequent migrations

### DIFF
--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -57,6 +57,20 @@ module Sequent
               ensure_rack_env_set!
               Sequent::Migrations::SequentSchema.create_sequent_schema_if_not_exists(env: @env, fail_if_exists: true)
             end
+
+            desc 'Utility tasks that can be used to guard against unsafe usage of rails db:migrate directly'
+            task :dont_use_db_migrate_directly do
+              fail <<~EOS unless ENV['SEQUENT_MIGRATION_SCHEMAS'].present?
+                Don't call rails db:migrate directly but wrap in your own task instead:
+
+                  task :migrate_db do
+                    ENV['SEQUENT_SCHEMAS'] = 'public'
+                    Rake::Task['db:migrate'].invoke
+                  end
+
+                You can choose whatever name for migrate_db you like.
+              EOS
+            end
           end
 
           namespace :migrate do


### PR DESCRIPTION
The problem occurs when rails migrations are run after the view_schema and sequent_schema
are created and the migrations run when `schema_search_path` is set to contain both
the active record schema as well and the sequent schema's.
To get around this one must wrap `rails db:migrate` with a custom task in order to
set the `schema_search_path` to only contain the active record schema.
A better way would be to prepend something to `Rake::Task['db:migrate']` but there is only
`enchance` which will add a task as last one of the prerequisites.
