### PR TITLE
Introduce SEQUENT_ENV

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,7 +9,7 @@ on:
       - '**'
 
 env:
-  RACK_ENV: test
+  SEQUENT_ENV: test
   POSTGRES_USERNAME: sequent
   POSTGRES_PASSWORD: sequent
   POSTGRES_DB: sequent_spec_db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 - Changed the default type of `aggregate_id` in `sequent_schema` to `uuid` since Postgres support this for quite long.
 - Added support for applications using ActiveRecord multiple database connections feature
-**BREAKING CHANGES**: 
+- Improved out-of-the-box Rails support by fixing various bugs and providing Rake task to ease integration. See
+  for more details: https://www.sequent.io/docs/rails-sequent.html
+- Introduce `SEQUENT_ENV` instead of `RACK_ENV`. `SEQUENT_ENV` defaults to the value of `RAILS_ENV` or `RACK_ENV`.
+
+**BREAKING CHANGES**:
+
 - Renamed file of `Sequent::Test::WorkflowHelpers` to `workflow_helpers`. If you require this file manually you will need to update it's references
 - You now must "tag" specs using `Sequent::Test::WorkflowHelpers` with the following metadata `workflows: true` to avoid collision with other specs
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,14 @@ Then run `rake release`. A git tag will be created and pushed, and the new versi
 
 ## Running the specs
 
-If you wish to make changes to the `sequent` gem you can use `rake spec` to run the tests. Before doing so you need to create a postgres
-user and database first:
+First create the database if you did not already do so:
 
 ```sh
 createuser -D -s -R sequent
-createdb sequent_spec_db -O sequent
-RACK_ENV=test bundle exec rake sequent:db:create
+SEQUENT_ENV=test bundle exec rake sequent:db:create
 ```
 
-The data in this database is deleted every time you run the specs!
+Run `rspec spec` to run the tests.
 
 ## Changelog
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ Database.write_database_yml_for_test(env: 'test')
 task 'sequent:migrate:init' => [:db_connect]
 
 task 'db_connect' do
-  Sequent::Support::Database.connect!(ENV['RACK_ENV'])
+  Sequent::Support::Database.connect!(ENV['SEQUENT_ENV'])
 end
 
 Bundler::GemHelper.install_tasks

--- a/bin/sequent
+++ b/bin/sequent
@@ -31,7 +31,7 @@ def new_project(args)
       bundle exec rake sequent:migrate:offline
 
     Run the example specs:
-      RACK_ENV=test bundle exec rake sequent:db:create
+      SEQUENT_ENV=test bundle exec rake sequent:db:create
       bundle exec rspec spec
 
     To generate new aggregates use:

--- a/docs/docs/building-a-web-application.md
+++ b/docs/docs/building-a-web-application.md
@@ -141,11 +141,11 @@ require 'sequent'
 
 class Database
   class << self
-    def database_config(env = ENV['RACK_ENV'])
+    def database_config(env = ENV['SEQUENT_ENV'])
       @config ||= YAML.load(ERB.new(File.read('db/database.yml')).result)[env]
     end
 
-    def establish_connection(env = ENV['RACK_ENV'])
+    def establish_connection(env = ENV['SEQUENT_ENV'])
       config = database_config(env)
       yield(config) if block_given?
       Sequent::ApplicationRecord.configurations = { env.to_s => config.stringify_keys }

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -108,7 +108,7 @@ Now let's finish our setup by installing the gems and preparing the database:
 ```bash
 bundle install
 bundle exec rake sequent:db:create
-RACK_ENV=test bundle exec rake sequent:db:create
+SEQUENT_ENV=test bundle exec rake sequent:db:create
 bundle exec rake sequent:db:create_view_schema
 bundle exec rake sequent:migrate:online
 bundle exec rake sequent:migrate:offline

--- a/docs/docs/rails-sequent.md
+++ b/docs/docs/rails-sequent.md
@@ -51,9 +51,9 @@ See for more details the [Rails autoloading and reloading guide](https://guides.
 5. Add the following snippet to your `Rakefile`
 
     ```ruby
-    # Sequent requires a `RACK_ENV` environment to be set
+    # Sequent requires a `SEQUENT_ENV` environment to be set
     # next to a `RAILS_ENV` 
-    ENV['RACK_ENV'] = ENV['RAILS_ENV'] ||= 'development'
+    ENV['SEQUENT_ENV'] = ENV['RAILS_ENV'] ||= 'development'
     
     require 'sequent/rake/migration_tasks'
     
@@ -67,7 +67,7 @@ See for more details the [Rails autoloading and reloading guide](https://guides.
     task 'sequent:migrate:init' => [:sequent_db_connect]
     
     task 'sequent_db_connect' do
-      Sequent::Support::Database.connect!(ENV['RACK_ENV'])
+      Sequent::Support::Database.connect!(ENV['SEQUENT_ENV'])
     end
    
     # Create custom rake task setting the SEQUENT_MIGRATION_SCHEMAS for

--- a/lib/sequent/generator/template_project/Rakefile
+++ b/lib/sequent/generator/template_project/Rakefile
@@ -1,4 +1,4 @@
-ENV['RACK_ENV'] ||= 'development'
+ENV['SEQUENT_ENV'] ||= 'development'
 
 require './my_app'
 require 'sequent/rake/migration_tasks'
@@ -8,5 +8,5 @@ Sequent::Rake::MigrationTasks.new.register_tasks!
 task "sequent:migrate:init" => [:db_connect]
 
 task "db_connect" do
-  Sequent::Support::Database.connect!(ENV['RACK_ENV'])
+  Sequent::Support::Database.connect!(ENV['SEQUENT_ENV'])
 end

--- a/lib/sequent/generator/template_project/spec/spec_helper.rb
+++ b/lib/sequent/generator/template_project/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require 'bundler/setup'
 Bundler.setup
 
-ENV['RACK_ENV'] ||= 'test'
+ENV['SEQUENT_ENV'] ||= 'test'
 
 require 'sequent/test'
 require 'database_cleaner'

--- a/lib/sequent/support/database.rb
+++ b/lib/sequent/support/database.rb
@@ -83,7 +83,7 @@ module Sequent
         execute_sql "DROP SCHEMA if exists #{schema_name} cascade"
       end
 
-      def self.with_schema_search_path(search_path, db_config, env = ENV['RACK_ENV'])
+      def self.with_schema_search_path(search_path, db_config, env = ENV['SEQUENT_ENV'])
         fail ArgumentError, 'env is required' unless env
 
         disconnect!

--- a/spec/lib/sequent/core/command_spec.rb
+++ b/spec/lib/sequent/core/command_spec.rb
@@ -17,7 +17,7 @@ describe Sequent::Core::BaseCommand do
       expect { Sequent::Core::Command.new }.to raise_error(/Missing aggregate_id/)
     end
 
-    it "after_initialize works" do
+    it 'after_initialize works' do
       class AfterInitCommand < Sequent::Command
         attrs flag: Boolean
 

--- a/spec/lib/sequent/generator/project_spec.rb
+++ b/spec/lib/sequent/generator/project_spec.rb
@@ -62,7 +62,7 @@ describe Sequent::Generator::Project do
     Bundler.with_unbundled_env do
       system 'bash', '-cex', <<~SCRIPT
         cd blog-with_special-symbols
-        export RACK_ENV=test
+        export SEQUENT_ENV=test
 
         if which rbenv; then
           eval "$(rbenv init - bash)"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'bundler/setup'
 Bundler.setup
 
-ENV['RACK_ENV'] ||= 'test'
+ENV['SEQUENT_ENV'] ||= 'test'
 
 require 'rspec/collection_matchers'
 require 'timecop'
@@ -17,8 +17,8 @@ SimpleCov.start if ENV['COVERAGE']
 require_relative 'database'
 
 Sequent.configuration.database_config_directory = 'tmp'
-Database.write_database_yml_for_test(env: ENV['RACK_ENV'])
-Sequent::Test::DatabaseHelpers.maintain_test_database_schema(env: ENV['RACK_ENV'])
+Database.write_database_yml_for_test(env: ENV['SEQUENT_ENV'])
+Sequent::Test::DatabaseHelpers.maintain_test_database_schema(env: ENV['SEQUENT_ENV'])
 
 RSpec.configure do |c|
   c.before do


### PR DESCRIPTION
Prior to SEQUENT_ENV it relied on RACK_ENV being set mainly due to historic reasons.
In Rake tasks it will use the RAILS_ENV or RACK_ENV as value of SEQUENT_ENV if not set to ease
integration with Rails and frameworks like Sinatra who might use RACK_ENV.
