### PR TITLE
Replay events using BETWEEN predicate on aggregate_id

### DIFF
--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -346,7 +346,7 @@ module Sequent
           prefix = format('%0*x', exponent, i)
           lowerbound = prefix + '00000000-0000-0000-0000-000000000000'[exponent..-1]
           upperbound = prefix + 'ffffffff-ffff-ffff-ffff-ffffffffffff'[exponent..-1]
-          (lowerbound .. upperbound)
+          (lowerbound..upperbound)
         end
       end
 


### PR DESCRIPTION
Instead of using a prefix with a separate index. This will allow us to drop the `replay_events` index on `event_type,
substring(aggregate_id::text, 1, 3)` since it uses the existing `unique_event_per_aggregate` index instead.

This implementation is slower though when only a few event types need to be replayed, instead of all events. Not sure if this is a big problem or not.