### PR TITLE
Use PostgreSQL stored procedures for loading and storing events

### DIFF
--- a/db/sequent_schema.rb
+++ b/db/sequent_schema.rb
@@ -100,11 +100,11 @@ LANGUAGE plpgsql;
 }
 
   execute %q{
-CREATE OR REPLACE PROCEDURE store_events(_command_record_id command_records.id%TYPE, _streams_with_events JSONB) AS
+CREATE OR REPLACE PROCEDURE store_events(_command_record_id command_records.id%TYPE, _aggregates_with_events JSONB) AS
 $$
 DECLARE
-  _stream JSONB;
-  _stream_without_nulls JSONB;
+  _aggregate JSONB;
+  _aggregate_without_nulls JSONB;
   _events JSONB;
   _event JSONB;
   _aggregate_id stream_records.aggregate_id%TYPE;
@@ -113,21 +113,21 @@ DECLARE
   _snapshot_threshold stream_records.snapshot_threshold%TYPE;
   _sequence_number event_records.sequence_number%TYPE;
 BEGIN
-  FOR _stream, _events IN SELECT row->0, row->1 FROM jsonb_array_elements(_streams_with_events) AS row LOOP
-    _aggregate_id = _stream->>'aggregate_id';
-    _stream_without_nulls = jsonb_strip_nulls(_stream);
-    _snapshot_threshold = _stream_without_nulls->'snapshot_threshold';
+  FOR _aggregate, _events IN SELECT row->0, row->1 FROM jsonb_array_elements(_aggregates_with_events) AS row LOOP
+    _aggregate_id = _aggregate->>'aggregate_id';
+    _aggregate_without_nulls = jsonb_strip_nulls(_aggregate);
+    _snapshot_threshold = _aggregate_without_nulls->'snapshot_threshold';
 
     SELECT id INTO _stream_record_id FROM stream_records WHERE aggregate_id = _aggregate_id;
     IF NOT FOUND THEN
       _created_at = _events->0->'created_at';
       _sequence_number = _events->0->'sequence_number';
       IF _sequence_number <> 1 THEN
-        RAISE EXCEPTION 'sequence number of first event new stream must be 1, was %', _sequence_number;
+        RAISE EXCEPTION 'sequence number of first event new aggregate must be 1, was %', _sequence_number;
       END IF;
 
       INSERT INTO stream_records (created_at, aggregate_type, aggregate_id, snapshot_threshold)
-           VALUES (_created_at, _stream->>'aggregate_type', _aggregate_id, _snapshot_threshold)
+           VALUES (_created_at, _aggregate->>'aggregate_type', _aggregate_id, _snapshot_threshold)
         RETURNING id
              INTO STRICT _stream_record_id;
     END IF;

--- a/db/sequent_schema.rb
+++ b/db/sequent_schema.rb
@@ -58,7 +58,12 @@ ALTER TABLE event_records ADD CONSTRAINT stream_fkey FOREIGN KEY (stream_record_
 }
 
   execute %q{
-CREATE OR REPLACE FUNCTION load_events(_aggregate_ids JSONB, _snapshot_event_type event_records.event_type%TYPE, _use_snapshots BOOLEAN DEFAULT TRUE) RETURNS SETOF event_records AS $$
+CREATE OR REPLACE FUNCTION load_events(
+  _aggregate_ids JSONB,
+  _snapshot_event_type event_records.event_type%TYPE,
+  _use_snapshots BOOLEAN DEFAULT TRUE,
+  _until event_records.created_at%TYPE DEFAULT NULL
+) RETURNS SETOF event_records AS $$
 DECLARE
   _aggregate_id event_records.aggregate_id%TYPE;
   _snapshot_event event_records;
@@ -85,6 +90,7 @@ BEGIN
                   WHERE aggregate_id = _aggregate_id
                     AND sequence_number >= _snapshot_event_sequence_number
                     AND event_type <> _snapshot_event_type
+                    AND (_until IS NULL OR created_at < _until)
                   ORDER BY sequence_number;
   END LOOP;
 END;

--- a/db/sequent_schema.rb
+++ b/db/sequent_schema.rb
@@ -114,7 +114,7 @@ DECLARE
   _sequence_number event_records.sequence_number%TYPE;
 BEGIN
   FOR _aggregate, _events IN SELECT row->0, row->1 FROM jsonb_array_elements(_aggregates_with_events) AS row LOOP
-    _aggregate_id = _aggregate->>'aggregate_id';
+    _aggregate_id = (_aggregate->>'aggregate_id')::uuid;
     _aggregate_without_nulls = jsonb_strip_nulls(_aggregate);
     _snapshot_threshold = _aggregate_without_nulls->'snapshot_threshold';
 
@@ -137,7 +137,7 @@ BEGIN
       _sequence_number = _event->'sequence_number';
       INSERT INTO event_records (aggregate_id, sequence_number, created_at, event_type, event_json, command_record_id, stream_record_id)
            VALUES (
-             _event->>'aggregate_id',
+             (_event->>'aggregate_id')::uuid,
              _sequence_number,
              _created_at,
              _event->>'event_type',

--- a/db/sequent_schema.rb
+++ b/db/sequent_schema.rb
@@ -118,6 +118,11 @@ BEGIN
     SELECT id INTO _stream_record_id FROM stream_records WHERE aggregate_id = _aggregate_id;
     IF NOT FOUND THEN
       _created_at = _events->0->'created_at';
+      _sequence_number = _events->0->'sequence_number';
+      IF _sequence_number <> 1 THEN
+        RAISE EXCEPTION 'sequence number of first event new stream must be 1, was %', _sequence_number;
+      END IF;
+
       INSERT INTO stream_records (created_at, aggregate_type, aggregate_id, snapshot_threshold)
            VALUES (_created_at, _stream->>'aggregate_type', _aggregate_id, _snapshot_threshold)
         RETURNING id

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -246,9 +246,9 @@ module Sequent
             uncommitted_events.map do |event|
               r = Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))
               # Since ActiveRecord uses `TIMESTAMP WITHOUT TIME ZONE`
-              # we need to manually convert database timestamps to UTC
-              # on serialization
-              r['created_at'] = event.created_at.to_time.utc
+              # we need to manually convert database timestamps to the
+              # ActiveRecord default time zone on serialization.
+              r['created_at'] = ActiveRecord.default_timezone == :utc ? event.created_at.to_time.getutc : event.created_at.to_time.getlocal
               r['event_type'] = event.class.name
               r
             end,

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -238,8 +238,8 @@ module Sequent
           stream = Oj.strict_load(Oj.dump(event_stream))
           [stream, uncommitted_events.map { |event|
              r = Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))
-             # Since Rails uses `TIMESTAMP WITHOUT TIME ZONE` we need to manually convert database timestamps to UTC on serialization
-             r['created_at'] = event.created_at.utc
+             # Since ActiveRecord uses `TIMESTAMP WITHOUT TIME ZONE` we need to manually convert database timestamps to UTC on serialization
+             r['created_at'] = event.created_at.to_time.utc
              r['event_type'] = event.class.name
              r
            }]

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -248,7 +248,7 @@ module Sequent
         json = streams_with_events.map do |event_stream, uncommitted_events|
           stream = Oj.strict_load(Oj.dump(event_stream))
           [stream, uncommitted_events.map { |event|
-             r = Oj.strict_load(Sequent.configuration.event_record_class.serialize_to_json(event))
+             r = Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event))
              # Since Rails uses `TIMESTAMP WITHOUT TIME ZONE` we need to manually convert database timestamps to UTC on serialization
              r['created_at'] = event.created_at.utc
              r['event_type'] = event.class.name

--- a/lib/sequent/support/view_projection.rb
+++ b/lib/sequent/support/view_projection.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'postgresql_cursor'
+
+module Sequent
+  module Support
+    class ViewProjection
+      attr_reader :name, :version, :schema_definition
+
+      def initialize(options)
+        @name = options.fetch(:name)
+        @version = options.fetch(:version)
+        @schema_definition = options.fetch(:definition)
+        @replay_event_handlers = options.fetch(:event_handlers)
+      end
+
+      def build!
+        with_default_configuration do
+          Sequent.configuration.event_handlers = @replay_event_handlers
+
+          load schema_definition
+          event_store = Sequent.configuration.event_store
+          ordering = Events::ORDERED_BY_STREAM
+          event_store.replay_events_from_cursor(
+            block_size: 10_000,
+            get_events: -> { ordering[event_store] },
+          )
+        end
+      end
+
+      def schema_name
+        "#{name}_#{version}"
+      end
+
+      private
+
+      def with_default_configuration
+        original_configuration = Sequent.configuration
+        Sequent::Configuration.reset
+        yield
+        Sequent::Configuration.restore(original_configuration)
+      end
+    end
+
+    module Events
+      extend ActiveRecord::ConnectionAdapters::Quoting
+
+      ORDERED_BY_STREAM = ->(_event_store) do
+        snapshot_event_type = quote(Sequent.configuration.snapshot_event_class)
+
+        Sequent.configuration.event_record_class
+          .select('event_type, event_json')
+          .where("event_type <> #{snapshot_event_type}")
+          .order!('stream_record_id, sequence_number')
+      end
+    end
+  end
+end

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -6,6 +6,7 @@ require 'postgresql_cursor'
 
 describe Sequent::Core::EventStore do
   class MyEvent < Sequent::Core::Event
+    attrs data: String
   end
 
   let(:event_store) { Sequent.configuration.event_store }
@@ -50,7 +51,7 @@ describe Sequent::Core::EventStore do
               aggregate_id: aggregate_id,
               snapshot_threshold: 13,
             ),
-            [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)],
+            [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1, data: "with ' unsafe SQL characters;\n")],
           ],
         ],
       )
@@ -62,6 +63,7 @@ describe Sequent::Core::EventStore do
       expect(stream.aggregate_id).to eq(aggregate_id)
       expect(events.first.aggregate_id).to eq(aggregate_id)
       expect(events.first.sequence_number).to eq(1)
+      expect(events.first.data).to eq("with ' unsafe SQL characters;\n")
     end
 
     it 'can find streams that need snapshotting' do

--- a/spec/lib/sequent/migrations/view_schema_spec.rb
+++ b/spec/lib/sequent/migrations/view_schema_spec.rb
@@ -437,8 +437,8 @@ describe Sequent::Migrations::ViewSchema do
         insert_events(
           'Account',
           [
+            AccountCreated.new(aggregate_id: account_id_2, sequence_number: 1),
             AccountCreated.new(aggregate_id: account_id_2, sequence_number: 2),
-            AccountCreated.new(aggregate_id: account_id_2, sequence_number: 3),
           ],
         )
 
@@ -483,8 +483,8 @@ describe Sequent::Migrations::ViewSchema do
           insert_events(
             'Account',
             [
+              AccountCreated.new(aggregate_id: account_id_2, sequence_number: 1),
               AccountCreated.new(aggregate_id: account_id_2, sequence_number: 2),
-              AccountCreated.new(aggregate_id: account_id_2, sequence_number: 3),
             ],
           )
 


### PR DESCRIPTION
This is in preparation of optimizing the schema to reduce space requirements and allow for table partitioning. By using the stored procedures as an interface to the database the schema can be changed and (incrementally) migrated without requiring downtime.