### PR TITLE
Fix typo in AggregateRoot docs

### DIFF
--- a/docs/docs/concepts/aggregate-root.md
+++ b/docs/docs/concepts/aggregate-root.md
@@ -92,7 +92,7 @@ class User < Sequent::AggregateRoot
   end
 
   on UserNameSet do |event|
-    @name = name
+    @name = event.name
   end
 end
 ```


### PR DESCRIPTION
I found a small typo in the AggregateRoot docs.