### PR TITLE
Add option to not cache event types

### DIFF
--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -26,8 +26,21 @@ module Sequent
         end
       end
 
-      def initialize
-        @event_types = ThreadSafe::Cache.new
+      ##
+      # Disables event type caching (ie. for in development).
+      #
+      class NoEventTypesCache
+        def fetch_or_store(event_type)
+          yield(event_type)
+        end
+      end
+
+      def initialize(cache_event_types: true)
+        @event_types = if cache_event_types
+                         ThreadSafe::Cache.new
+                       else
+                         NoEventTypesCache.new
+                       end
       end
 
       ##

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -195,7 +195,7 @@ describe Sequent::Core::EventStore do
         )
         stream, events = event_store.load_events(aggregate_id)
         expect(stream).to be
-        expect(events).to eq([TestEventForCaching.new(aggregate_id: aggregate_id, sequence_number: 1)])
+        expect(events.first).to be_kind_of(TestEventForCaching)
 
         # redefine TestEventForCaching class (ie. simulate Rails auto-loading)
         OldTestEventForCaching = TestEventForCaching
@@ -203,7 +203,7 @@ describe Sequent::Core::EventStore do
 
         stream, events = event_store.load_events(aggregate_id)
         expect(stream).to be
-        expect(events).to eq([TestEventForCaching.new(aggregate_id: aggregate_id, sequence_number: 1)])
+        expect(events.first).to be_kind_of(TestEventForCaching)
       end
     end
   end

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -182,26 +182,28 @@ describe Sequent::Core::EventStore do
       let(:event_store) { Sequent::Core::EventStore.new(cache_event_types: false) }
 
       it 'returns the stream and events for existing aggregates' do
+        TestEventForCaching = Class.new(Sequent::Core::Event)
+
         event_store.commit_events(
           Sequent::Core::CommandRecord.new,
           [
             [
               Sequent::Core::EventStream.new(aggregate_type: 'MyAggregate', aggregate_id: aggregate_id),
-              [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)],
+              [TestEventForCaching.new(aggregate_id: aggregate_id, sequence_number: 1)],
             ],
           ],
         )
         stream, events = event_store.load_events(aggregate_id)
         expect(stream).to be
-        expect(events).to eq([MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)])
+        expect(events).to eq([TestEventForCaching.new(aggregate_id: aggregate_id, sequence_number: 1)])
 
-        # redefine MyEvent class (ie. simulate Rails auto-loading)
-        OldMyEvent = MyEvent
-        MyEvent = Class.new(Sequent::Core::Event)
+        # redefine TestEventForCaching class (ie. simulate Rails auto-loading)
+        OldTestEventForCaching = TestEventForCaching
+        TestEventForCaching = Class.new(Sequent::Core::Event)
 
         stream, events = event_store.load_events(aggregate_id)
         expect(stream).to be
-        expect(events).to eq([MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)])
+        expect(events).to eq([TestEventForCaching.new(aggregate_id: aggregate_id, sequence_number: 1)])
       end
     end
   end

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -177,6 +177,33 @@ describe Sequent::Core::EventStore do
       expect(stream).to be
       expect(events).to be
     end
+
+    context 'and event type caching disabled' do
+      let(:event_store) { Sequent::Core::EventStore.new(cache_event_types: false) }
+
+      it 'returns the stream and events for existing aggregates' do
+        event_store.commit_events(
+          Sequent::Core::CommandRecord.new,
+          [
+            [
+              Sequent::Core::EventStream.new(aggregate_type: 'MyAggregate', aggregate_id: aggregate_id),
+              [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)],
+            ],
+          ],
+        )
+        stream, events = event_store.load_events(aggregate_id)
+        expect(stream).to be
+        expect(events).to eq([MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)])
+
+        # redefine MyEvent class (ie. simulate Rails auto-loading)
+        OldMyEvent = MyEvent
+        MyEvent = Class.new(Sequent::Core::Event)
+
+        stream, events = event_store.load_events(aggregate_id)
+        expect(stream).to be
+        expect(events).to eq([MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)])
+      end
+    end
   end
 
   describe '#load_events_for_aggregates' do


### PR DESCRIPTION
When using Rails auto-loading, classes should not be cached.

> Bottom line: do not cache reloadable classes or modules.

Source: https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#reloading-and-stale-objects

The `Sequent::Core::EventStore` caches event classes by default (which is good, because it removes the need for unnecessary slow constant lookups). When using Rails in development we want to disable this, otherwise the `on` blocks registered in objects such as `Sequent::AggregateRoot`s aren't called properly (because the cached (old) event class does not match the one registered in a message handler).

Usage:

```ruby
Sequent.configure do |config|
  config.event_store = Sequent::Core::EventStore.new(cache_event_types: !Rails.env.development)
end
```

The `cache_event_types` argument has a default value of `true` for backward compatiblity.