### PR TITLE
Add time as supported type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
-# Changelog 5.x (changes since 5.0.0)
+# Changelog 6.x (changes since 5.0.0)
 
 - Changed the default type of `aggregate_id` in `sequent_schema` to `uuid` since Postgres support this for quite long.
 - Added support for applications using ActiveRecord multiple database connections feature
 - Improved out-of-the-box Rails support by fixing various bugs and providing Rake task to ease integration. See
   for more details: https://www.sequent.io/docs/rails-sequent.html
 - Introduce `SEQUENT_ENV` instead of `RACK_ENV`. `SEQUENT_ENV` defaults to the value of `RAILS_ENV` or `RACK_ENV`.
+- Introduce `Sequent.configuration.time_precision` which defaults to `ActiveSupport::JSON::Encoding.time_precision`
+  which is the precision "after seconds" to store time in json format when an event is serialized.
 
 **BREAKING CHANGES**:
 
+- Since `DateTime` is deprecated in the Ruby std lib the standard attribute `created_at` of `Event` and `Command` is now a `Time`.
+  This should not be a problem when serializing an deserializing but might be breaking in your could if you rely on the fact
+  it being a `DateTime` rather then a `Time`.
 - Renamed file of `Sequent::Test::WorkflowHelpers` to `workflow_helpers`. If you require this file manually you will need to update it's references
 - You now must "tag" specs using `Sequent::Test::WorkflowHelpers` with the following metadata `workflows: true` to avoid collision with other specs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 **BREAKING CHANGES**:
 
 - Since `DateTime` is deprecated in the Ruby std lib the standard attribute `created_at` of `Event` and `Command` is now a `Time`.
-  This should not be a problem when serializing an deserializing but might be breaking in your could if you rely on the fact
-  it being a `DateTime` rather then a `Time`.
+  This should not be a problem when serializing an deserializing but might be breaking if you rely on the fact
+  it being a `DateTime` rather than a `Time`.
 - Renamed file of `Sequent::Test::WorkflowHelpers` to `workflow_helpers`. If you require this file manually you will need to update it's references
 - You now must "tag" specs using `Sequent::Test::WorkflowHelpers` with the following metadata `workflows: true` to avoid collision with other specs
 

--- a/docs/docs/concepts/types.md
+++ b/docs/docs/concepts/types.md
@@ -17,6 +17,7 @@ Out of the box Sequent supports the following types:
 1. [Integer](#integer)
 1. [Date](#date)
 1. [DateTime](#datetime)
+1. [Time](#time)
 1. [Boolean](#boolean)
 1. [Symbol](#symbol)
 1. [ValueObjects](#valueobjects)
@@ -58,9 +59,19 @@ a Command is passed to the [CommandService](command-service.html).
 
 ## DateTime
 
+**DEPRECATED** Use `Time` instead
+
 Usage `attrs created_at: DateTime`
 
 Accepts all `DateTime` objects. To accommodate user input valid
+iso8601 datetime Strings are parsed automatically when
+a Command is passed to the CommandService.
+
+## Time
+
+Usage `attrs created_at: Time`
+
+Accepts all `Time` objects. To accommodate user input valid
 iso8601 datetime Strings are parsed automatically when
 a Command is passed to the CommandService.
 

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -32,6 +32,8 @@ module Sequent
 
     DEFAULT_ERROR_LOCALE_RESOLVER = -> { I18n.locale || :en }
 
+    DEFAULT_TIME_PRECISION = ActiveSupport::JSON::Encoding.time_precision
+
     attr_accessor :aggregate_repository,
                   :event_store,
                   :command_service,
@@ -59,7 +61,8 @@ module Sequent
                   :strict_check_attributes_on_apply_events,
                   :enable_multiple_database_support,
                   :primary_database_role,
-                  :primary_database_key
+                  :primary_database_key,
+                  :time_precision
 
     attr_reader :migrations_class_name,
                 :versions_table_name,
@@ -114,6 +117,8 @@ module Sequent
       self.enable_multiple_database_support = false
       self.primary_database_role = :writing
       self.primary_database_key = :primary
+
+      self.time_precision = DEFAULT_TIME_PRECISION
     end
 
     def can_use_multiple_databases?

--- a/lib/sequent/core/aggregate_root.rb
+++ b/lib/sequent/core/aggregate_root.rb
@@ -127,7 +127,7 @@ module Sequent
       # Provide subclasses nice DSL to 'apply' events via:
       #
       #   def send_invoice
-      #     apply InvoiceSentEvent, send_date: DateTime.now
+      #     apply InvoiceSentEvent, send_date: Time.now
       #   end
       #
       def apply(event, params = {})

--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -29,13 +29,13 @@ module Sequent
       include ActiveModel::Validations::Callbacks
       include Sequent::Core::Helpers::TypeConversionSupport
 
-      attrs created_at: DateTime
+      attrs created_at: Time
 
       define_model_callbacks :initialize, only: :after
 
       def initialize(args = {})
         update_all_attributes args
-        @created_at = DateTime.now
+        @created_at = Time.now
 
         _run_initialize_callbacks
       end

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -13,14 +13,14 @@ module Sequent
       include Sequent::Core::Helpers::AttributeSupport
       include Sequent::Core::Helpers::EqualSupport
       include Sequent::Core::Helpers::StringSupport
-      attrs aggregate_id: String, sequence_number: Integer, created_at: DateTime
+      attrs aggregate_id: String, sequence_number: Integer, created_at: Time
 
       def initialize(args = {})
         update_all_attributes args
         fail 'Missing aggregate_id' unless @aggregate_id
         fail 'Missing sequence_number' unless @sequence_number
 
-        @created_at ||= DateTime.now
+        @created_at ||= Time.now
       end
 
       def payload

--- a/lib/sequent/core/ext/ext.rb
+++ b/lib/sequent/core/ext/ext.rb
@@ -78,7 +78,8 @@ class Time
   def self.deserialize_from_json(value)
     value.blank? ? nil : Time.iso8601(value.dup)
   rescue ArgumentError => e
-    return Time.parse(value.dup) if e.message =~ /invalid xmlschema format/
+    return Time.parse(value.dup) if e.message =~ /invalid xmlschema format/ # ruby >= 3
+    return Time.parse(value.dup) if e.message =~ /invalid date:/ # ruby 2.7
 
     raise
   end

--- a/lib/sequent/core/ext/ext.rb
+++ b/lib/sequent/core/ext/ext.rb
@@ -77,6 +77,10 @@ class Time
 
   def self.deserialize_from_json(value)
     value.blank? ? nil : Time.iso8601(value.dup)
+  rescue ArgumentError => e
+    return Time.parse(value.dup) if e.message =~ /invalid xmlschema format/
+
+    raise
   end
 end
 

--- a/lib/sequent/core/ext/ext.rb
+++ b/lib/sequent/core/ext/ext.rb
@@ -68,6 +68,18 @@ class DateTime
   end
 end
 
+class Time
+  def self.from_params(value)
+    value.blank? ? nil : Time.iso8601(value.dup)
+  rescue ArgumentError
+    value
+  end
+
+  def self.deserialize_from_json(value)
+    value.blank? ? nil : Time.iso8601(value.dup)
+  end
+end
+
 class Array
   def self.deserialize_from_json(value)
     value

--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -6,6 +6,7 @@ require_relative 'array_with_type'
 require_relative 'default_validators'
 require_relative 'type_conversion_support'
 require_relative 'date_time_validator'
+require_relative 'time_validator'
 require_relative 'association_validator'
 
 module Sequent

--- a/lib/sequent/core/helpers/default_validators.rb
+++ b/lib/sequent/core/helpers/default_validators.rb
@@ -17,6 +17,9 @@ module Sequent
           Date => ->(klass, field) do
             klass.validates field, 'sequent::Core::Helpers::Date' => true
           end,
+          Time => ->(klass, field) do
+            klass.validates field, 'sequent::Core::Helpers::Time' => true
+          end,
           DateTime => ->(klass, field) do
             klass.validates field, 'sequent::Core::Helpers::DateTime' => true
           end,

--- a/lib/sequent/core/helpers/param_support.rb
+++ b/lib/sequent/core/helpers/param_support.rb
@@ -83,6 +83,8 @@ module Sequent
             val.iso8601
           elsif val.is_a? Date
             val.iso8601
+          elsif val.is_a? Time
+            val.iso8601(Sequent.configuration.time_precision)
           else
             val
           end

--- a/lib/sequent/core/helpers/string_to_value_parsers.rb
+++ b/lib/sequent/core/helpers/string_to_value_parsers.rb
@@ -16,6 +16,7 @@ module Sequent
           ::Boolean => ->(value) { parse_to_bool(value) },
           ::Date => ->(value) { parse_to_date(value) },
           ::DateTime => ->(value) { parse_to_date_time(value) },
+          ::Time => ->(value) { parse_to_time(value) },
           ::Sequent::Core::Helpers::ArrayWithType => ->(values, type_in_array) { parse_array(values, type_in_array) },
           ::Sequent::Core::Helpers::Secret => ->(value) { Sequent::Core::Helpers::Secret.new(value).encrypt },
         }.freeze
@@ -50,6 +51,10 @@ module Sequent
 
         def self.parse_to_date_time(value)
           value.is_a?(DateTime) ? value : DateTime.deserialize_from_json(value)
+        end
+
+        def self.parse_to_time(value)
+          value.is_a?(Time) ? value : Time.deserialize_from_json(value)
         end
 
         def self.parse_array(values, type_in_array)

--- a/lib/sequent/core/helpers/time_validator.rb
+++ b/lib/sequent/core/helpers/time_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'active_model'
+
+module Sequent
+  module Core
+    module Helpers
+      # Validates Time
+      # Automatically included when using a
+      #
+      #   attrs value: Time
+      class TimeValidator < ActiveModel::EachValidator
+        def validate_each(subject, attribute, value)
+          return if value.is_a?(Time)
+
+          Time.deserialize_from_json(value)
+        rescue StandardError
+          subject.errors.add attribute, :invalid_time
+        end
+      end
+    end
+  end
+end

--- a/lib/sequent/core/helpers/value_validators.rb
+++ b/lib/sequent/core/helpers/value_validators.rb
@@ -16,6 +16,7 @@ module Sequent
           ::Integer => ->(value) { valid_integer?(value) },
           ::Boolean => ->(value) { valid_bool?(value) },
           ::Date => ->(value) { valid_date?(value) },
+          ::Time => ->(value) { valid_time?(value) },
           ::DateTime => ->(value) { valid_date_time?(value) },
         }.freeze
 
@@ -48,6 +49,16 @@ module Sequent
 
           begin
             value.is_a?(DateTime) || !!DateTime.iso8601(value.dup)
+          rescue StandardError
+            false
+          end
+        end
+
+        def self.valid_time?(value)
+          return true if value.blank?
+
+          begin
+            value.is_a?(Time) || !!Time.iso8601(value.dup)
           rescue StandardError
             false
           end

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -18,18 +18,18 @@ module Sequent
           desc <<~EOS
             Set the SEQUENT_ENV to RAILS_ENV or RACK_ENV if not already set
           EOS
-          task :environment do
+          task :set_env_var do
             ENV['SEQUENT_ENV'] ||= ENV['RAILS_ENV'] || ENV['RACK_ENV']
           end
 
           desc <<~EOS
-            Rake task that runs before all sequent rake tasks and after the environment is set.#{' '}
+            Rake task that runs before all sequent rake tasks and after the environment is set.
             Hook applications can use to for instance run other rake tasks:
 
               Rake::Task['sequent:init'].enhance(['my_task'])
 
           EOS
-          task init: :environment
+          task init: :set_env_var
 
           namespace :db do
             desc 'Creates the database and initializes the event_store schema for the current env'

--- a/lib/sequent/test/time_comparison.rb
+++ b/lib/sequent/test/time_comparison.rb
@@ -17,11 +17,8 @@ module Sequent
         # omit nsec in datetime comparisons
         def <=>(other)
           if other&.is_a?(DateTimePatches::Normalize)
-            result = normalize.iso8601 <=> other.normalize.iso8601
-            return result unless result == 0
-
-            # use usec here, which *truncates* the nsec (ie. like Postgres)
-            return normalize.usec <=> other.normalize.usec
+            precision = Sequent.configuration.time_precision
+            return normalize.iso8601(precision) <=> other.normalize.iso8601(precision)
           end
           public_send(:'___<=>', other)
         end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Sequent
-  VERSION = '5.0.0'
+  VERSION = '6.0.0'
 end

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require_relative '../../../fixtures/for_attribute_support'
+require 'sequent/test/time_comparison'
 
 describe Sequent::Core::Event do
   class TestEventEvent < Sequent::Core::Event
@@ -45,7 +46,8 @@ describe Sequent::Core::Event do
 
   it 'events are equal when deserialized from same attributes' do
     event1 = TestEventEvent.new(aggregate_id: 'foo', organization_id: 'bar', sequence_number: 1)
-    created_at = event1.created_at.iso8601
+    created_at = event1.created_at.iso8601(Sequent.configuration.time_precision)
+
     event2 = TestEventEvent.deserialize_from_json(
       'aggregate_id' => 'foo',
       'organization_id' => 'bar',

--- a/spec/lib/sequent/core/event_spec.rb
+++ b/spec/lib/sequent/core/event_spec.rb
@@ -114,4 +114,14 @@ describe Sequent::Core::Event do
       expect(event.attributes[:owner]).to_not have_key(:validation_context)
     end
   end
+
+  context 'created_at time' do
+    it 'will allow dates when already stored' do
+      event = {created_at: Date.new(2022, 1, 1), sequence_number: 1, aggregate_id: '1'}
+      deserialized_event = Sequent::Core::Event.deserialize_from_json(
+        Sequent::Core::Oj.strict_load(Sequent::Core::Oj.dump(event)),
+      )
+      expect(deserialized_event.created_at).to eq Time.parse('2022-01-01')
+    end
+  end
 end


### PR DESCRIPTION
[DateTime](https://ruby-doc.org/stdlib-3.1.0/libdoc/date/rdoc/DateTime.html) is considered deprecated. Sequent used `DateTime` for `created_at` of `Event` and `Command`.
This is potentially breaking when one serialized the DateTime in a custom format otherwise this change is fully backward compatible.