### PR TITLE
Use `ActiveSupport::DescendantsTracker`

### DIFF
--- a/lib/sequent/core/aggregate_root.rb
+++ b/lib/sequent/core/aggregate_root.rb
@@ -39,13 +39,9 @@ module Sequent
       include Helpers::MessageHandler
       include Helpers::AutosetAttributes
       include SnapshotConfiguration
+      extend ActiveSupport::DescendantsTracker
 
       attr_reader :id, :uncommitted_events, :sequence_number, :event_stream
-
-      def self.inherited(subclass)
-        super
-        AggregateRoots << subclass
-      end
 
       def self.load_from_history(stream, events)
         first, *rest = events

--- a/lib/sequent/core/aggregate_roots.rb
+++ b/lib/sequent/core/aggregate_roots.rb
@@ -5,18 +5,9 @@ module Sequent
     #
     # Utility class containing all subclasses of AggregateRoot.
     #
-    # WARNING: This class is deprecated and will be removed in the next major release.
-    # Please use Sequent::Core::AggregateRoot.descendants instead.
-    #
     class AggregateRoots
       class << self
         def aggregate_roots
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Sequent::Core::AggregateRoots is deprecated and will be removed in the next major release.
-
-            Use Sequent::AggregateRoot.descendants instead.
-          MSG
-
           Sequent::AggregateRoot.descendants
         end
 

--- a/lib/sequent/core/aggregate_roots.rb
+++ b/lib/sequent/core/aggregate_roots.rb
@@ -3,20 +3,25 @@
 module Sequent
   module Core
     #
-    # Utility class containing all subclasses of AggregateRoot
+    # Utility class containing all subclasses of AggregateRoot.
+    #
+    # WARNING: This class is deprecated and will be removed in the next major release.
+    # Please use Sequent::Core::AggregateRoot.descendants instead.
     #
     class AggregateRoots
       class << self
         def aggregate_roots
-          @aggregate_roots ||= []
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Sequent::Core::AggregateRoots is deprecated and will be removed in the next major release.
+
+            Use Sequent::AggregateRoot.descendants instead.
+          MSG
+
+          Sequent::AggregateRoot.descendants
         end
 
         def all
           aggregate_roots
-        end
-
-        def <<(aggregate_root)
-          aggregate_roots << aggregate_root
         end
       end
     end

--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -28,6 +28,7 @@ module Sequent
       include ActiveModel::Validations
       include ActiveModel::Validations::Callbacks
       include Sequent::Core::Helpers::TypeConversionSupport
+      extend ActiveSupport::DescendantsTracker
 
       attrs created_at: Time
 
@@ -38,11 +39,6 @@ module Sequent
         @created_at = Time.now
 
         _run_initialize_callbacks
-      end
-
-      def self.inherited(subclass)
-        super
-        Commands << subclass
       end
     end
 
@@ -60,20 +56,25 @@ module Sequent
     end
 
     #
-    # Utility class containing all subclasses of BaseCommand
+    # Utility class containing all subclasses of BaseCommand.
+    #
+    # WARNING: This class is deprecated and will be removed in the next major release.
+    # Please use Sequent::Core::BaseCommand.descendants instead.
     #
     class Commands
       class << self
         def commands
-          @commands ||= []
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Sequent::Core::Commands is deprecated and will be removed in the next major release.
+
+            Use Sequent::Core::BaseCommand.descendants instead.
+          MSG
+
+          Sequent::Core::BaseCommand.descendants
         end
 
         def all
           commands
-        end
-
-        def <<(command)
-          commands << command
         end
 
         def find(command_name)

--- a/lib/sequent/core/command.rb
+++ b/lib/sequent/core/command.rb
@@ -58,18 +58,9 @@ module Sequent
     #
     # Utility class containing all subclasses of BaseCommand.
     #
-    # WARNING: This class is deprecated and will be removed in the next major release.
-    # Please use Sequent::Core::BaseCommand.descendants instead.
-    #
     class Commands
       class << self
         def commands
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Sequent::Core::Commands is deprecated and will be removed in the next major release.
-
-            Use Sequent::Core::BaseCommand.descendants instead.
-          MSG
-
           Sequent::Core::BaseCommand.descendants
         end
 

--- a/lib/sequent/core/projector.rb
+++ b/lib/sequent/core/projector.rb
@@ -92,11 +92,6 @@ module Sequent
         @persistor = persistor
       end
 
-      def self.inherited(subclass)
-        super
-        Projectors << subclass
-      end
-
       def self.replay_persistor
         nil
       end
@@ -132,20 +127,25 @@ module Sequent
     end
 
     #
-    # Utility class containing all subclasses of Projector
+    # Utility class containing all subclasses of Projector.
+    #
+    # WARNING: This class is deprecated and will be removed in the next major release.
+    # Please use Sequent::Projector.descendants instead.
     #
     class Projectors
       class << self
         def projectors
-          @projectors ||= []
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Sequent::Core::Projectors is deprecated and will be removed in the next major release.
+
+            Use Sequent::Projector.descendants instead.
+          MSG
+
+          Sequent::Projector.descendants
         end
 
         def all
           projectors
-        end
-
-        def <<(projector)
-          projectors << projector
         end
 
         def find(projector_name)

--- a/lib/sequent/core/projector.rb
+++ b/lib/sequent/core/projector.rb
@@ -130,18 +130,9 @@ module Sequent
     #
     # Utility class containing all subclasses of Projector.
     #
-    # WARNING: This class is deprecated and will be removed in the next major release.
-    # Please use Sequent::Projector.descendants instead.
-    #
     class Projectors
       class << self
         def projectors
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Sequent::Core::Projectors is deprecated and will be removed in the next major release.
-
-            Use Sequent::Projector.descendants instead.
-          MSG
-
           Sequent::Projector.descendants
         end
 

--- a/lib/sequent/core/projector.rb
+++ b/lib/sequent/core/projector.rb
@@ -86,6 +86,7 @@ module Sequent
       extend Forwardable
       include Helpers::MessageHandler
       include Migratable
+      extend ActiveSupport::DescendantsTracker
 
       def initialize(persistor = Sequent::Core::Persistors::ActiveRecordPersistor.new)
         ensure_valid!

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -47,18 +47,9 @@ module Sequent
     #
     # Utility class containing all subclasses of Workflow.
     #
-    # WARNING: This class is deprecated and will be removed in the next major release.
-    # Please use Sequent::Workflow.descendants instead.
-    #
     class Workflows
       class << self
         def workflows
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            Sequent::Core::Workflows is deprecated and will be removed in the next major release.
-
-            Use Sequent::Workflow.descendants instead.
-          MSG
-
           Sequent::Workflow.descendants
         end
 

--- a/lib/sequent/core/workflow.rb
+++ b/lib/sequent/core/workflow.rb
@@ -7,11 +7,7 @@ module Sequent
   module Core
     class Workflow
       include Helpers::MessageHandler
-
-      def self.inherited(subclass)
-        super
-        Workflows << subclass
-      end
+      extend ActiveSupport::DescendantsTracker
 
       def self.on(*args, **opts, &block)
         decorated_block = ->(event) do
@@ -49,20 +45,25 @@ module Sequent
     end
 
     #
-    # Utility class containing all subclasses of Workflow
+    # Utility class containing all subclasses of Workflow.
+    #
+    # WARNING: This class is deprecated and will be removed in the next major release.
+    # Please use Sequent::Workflow.descendants instead.
     #
     class Workflows
       class << self
         def workflows
-          @workflows ||= []
+          ActiveSupport::Deprecation.warn(<<-MSG.squish)
+            Sequent::Core::Workflows is deprecated and will be removed in the next major release.
+
+            Use Sequent::Workflow.descendants instead.
+          MSG
+
+          Sequent::Workflow.descendants
         end
 
         def all
           workflows
-        end
-
-        def <<(workflow)
-          workflows << workflow
         end
 
         def find(workflow_name)

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -125,7 +125,7 @@ module Sequent
         def aggregate_type_for_event(event)
           @event_to_aggregate_type ||= ThreadSafe::Cache.new
           @event_to_aggregate_type.fetch_or_store(event.class) do |klass|
-            Sequent::Core::AggregateRoots.all.find { |x| x.message_mapping.key?(klass) }
+            Sequent::Core::AggregateRoot.descendants.find { |x| x.message_mapping.key?(klass) }
           end
         end
 

--- a/lib/sequent/util/dry_run.rb
+++ b/lib/sequent/util/dry_run.rb
@@ -66,7 +66,7 @@ module Sequent
         end
 
         def process_event(event)
-          [*Sequent::Core::Workflows.all, *Sequent::Core::Projector.descendants].each do |handler_class|
+          [*Sequent::Core::Workflow.descendants, *Sequent::Core::Projector.descendants].each do |handler_class|
             next unless handler_class.handles_message?(event)
 
             if handler_class < Sequent::Workflow

--- a/lib/sequent/util/dry_run.rb
+++ b/lib/sequent/util/dry_run.rb
@@ -66,7 +66,7 @@ module Sequent
         end
 
         def process_event(event)
-          [*Sequent::Core::Workflows.all, *Sequent::Core::Projectors.all].each do |handler_class|
+          [*Sequent::Core::Workflows.all, *Sequent::Core::Projector.descendants].each do |handler_class|
             next unless handler_class.handles_message?(event)
 
             if handler_class < Sequent::Workflow

--- a/spec/lib/sequent/util/dry_run_spec.rb
+++ b/spec/lib/sequent/util/dry_run_spec.rb
@@ -57,7 +57,7 @@ describe 'dry run' do
 
     before :each do
       allow(Sequent::Core::Workflows).to receive(:all).and_return([workflow])
-      allow(Sequent::Core::Projectors).to receive(:all).and_return([projector, projector_2])
+      allow(Sequent::Core::Projector).to receive(:descendants).and_return([projector, projector_2])
       # stub for current_event_store declaration in DryRun.these_commands method
       allow(Sequent.configuration)
         .to receive(:event_store)

--- a/spec/lib/sequent/util/dry_run_spec.rb
+++ b/spec/lib/sequent/util/dry_run_spec.rb
@@ -56,7 +56,7 @@ describe 'dry run' do
     end
 
     before :each do
-      allow(Sequent::Core::Workflows).to receive(:all).and_return([workflow])
+      allow(Sequent::Core::Workflow).to receive(:descendants).and_return([workflow])
       allow(Sequent::Core::Projector).to receive(:descendants).and_return([projector, projector_2])
       # stub for current_event_store declaration in DryRun.these_commands method
       allow(Sequent.configuration)


### PR DESCRIPTION
Use `ActiveSupport::DescendantsTracker` for fast subclass lookups.

> This module provides an internal implementation to track descendants which is faster than iterating through ObjectSpace.

Also see https://api.rubyonrails.org/classes/ActiveSupport/DescendantsTracker.html.

The following classes have been kept and use `.descendants` for fast lookups internally:

- `Sequent::Core::Commands`
- `Sequent::Core::AggregateRoots`
- `Sequent::Core::Projectors`
- `Sequent::Core::Workflows`
