### PR TITLE
Fix: Change db:migrate error message ENV

### DIFF
--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -75,7 +75,7 @@ module Sequent
                 Don't call rails db:migrate directly but wrap in your own task instead:
 
                   task :migrate_db do
-                    ENV['SEQUENT_SCHEMAS'] = 'public'
+                    ENV['SEQUENT_MIGRATION_SCHEMAS'] = 'public'
                     Rake::Task['db:migrate'].invoke
                   end
 


### PR DESCRIPTION
I continued to receive this error message about wrapping `db:migrate` even after creating a Rake task identical to the one in the error message. Upon investigation, looks like this `ENV` variable is supposed to match the one a few lines above.