### PR TITLE
Feat/guide improvements

### DIFF
--- a/docs/docs/building-a-web-application.md
+++ b/docs/docs/building-a-web-application.md
@@ -142,7 +142,7 @@ require 'sequent'
 class Database
   class << self
     def database_config(env = ENV['SEQUENT_ENV'])
-      @config ||= YAML.load(ERB.new(File.read('db/database.yml')).result)[env]
+      @config ||= YAML.load(ERB.new(File.read('db/database.yml')).result, aliases: true)[env]
     end
 
     def establish_connection(env = ENV['SEQUENT_ENV'])
@@ -157,9 +157,13 @@ end
 
 As you can see this is just a small wrapper for `ActiveRecord`. To establish the database connections on boot time we add a file `boot.rb`
 
-This will contain all the code needed to require and boot our app.
+This will contain all the code needed to require and boot our app. In the case that the SEQUENT_ENV is unset, we set it equal to 'development', which ensures the correct database config is loaded before connecting.
+
+`boot.rb`
 
 ```ruby
+ENV['SEQUENT_ENV'] ||= 'development'
+
 require './app/database'
 Database.establish_connection
 

--- a/docs/docs/finishing-the-web-application.md
+++ b/docs/docs/finishing-the-web-application.md
@@ -44,7 +44,7 @@ For this guide we somewhat refactored the web application and added bootstrap
 for some nifty look and feel and extracted some command erb code into
 a default layout, this is automatically picked up by Sinatra.
 
-In `app/view/layout.erb`
+In `app/views/layout.erb`
 ```ruby
 <html>
   <head>

--- a/docs/docs/modelling-the-domain.md
+++ b/docs/docs/modelling-the-domain.md
@@ -552,6 +552,12 @@ class Post < Sequent::AggregateRoot
     apply PostTitleChanged, title: command.title
     apply PostContentChanged, content: command.content
   end
+
+  # omitted ...
+  
+  on PostAuthorChanged do |event|
+    @author_aggregate_id = event.author_aggregate_id
+  end
 end
 ```
 


### PR DESCRIPTION
Some changes to ease the process of following the guide:
- Added fallback setting of SEQUENT_ENV to 'development' in `boot.rb`
- Set YAML loader to load aliases in `app/database.rb`
- update `on PostAuthorChanged` in `post.rb` to use field author_agregate_id rather than author
- fix minor spelling error in directory mention: `app/view/layout.erb` -> `app/views/layout.erb`