### PR TITLE
Update ViewSchema.create_view_tables method to execute alter migrations

### DIFF
--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -137,6 +137,16 @@ module Sequent
               statements = sql_file_to_statements(indexes_file_name) { |raw_sql| raw_sql.remove('%SUFFIX%') }
               statements.each(&method(:exec_sql))
             end
+
+            Dir.glob("#{Sequent.configuration.migration_sql_files_directory}/#{table.table_name}*.sql").each do |file_name|
+              next if file_name.include?("#{table.table_name}.indexes.sql")
+              next if file_name.include?("#{table.table_name}.sql")
+
+              statements = sql_file_to_statements(file_name) do |raw_sql|
+                raw_sql.remove('%SUFFIX%')
+              end
+              statements.each { |statement| exec_sql(statement) }
+            end
           end
           Versions.create!(version: Sequent.new_version)
         end


### PR DESCRIPTION
Currently I faced with an issue in my test environment that all `alter` migrations are ignored there. I found that when I call `Sequent::Test::DatabaseHelpers.maintain_test_database_schema` it calls only 2 methods: `create_sequent_schema_if_not_exists` and `create_view_tables`. And there is nothing about calling alter migrations.

I couldn't find any info about that neither in examples or docs. So I decided to update `create_view_tables` method. Let me know if it's possible to handle in different way or if you prefer to handle it in different way. 