### PR TITLE
Update rails-sequent.md

### DIFF
--- a/docs/docs/rails-sequent.md
+++ b/docs/docs/rails-sequent.md
@@ -79,6 +79,7 @@ See the [Rails autoloading and reloading guide](https://guides.rubyonrails.org/a
     task :migrate_public_schema do
       ENV['SEQUENT_MIGRATION_SCHEMAS'] = 'public'
       Rake::Task['db:migrate'].invoke
+      ENV['SEQUENT_MIGRATION_SCHEMAS'] = nil
     end
 
     # Prevent rails db:migrate from being executed directly.


### PR DESCRIPTION
Clear the SEQUENT_MIGRATION_SCHEMAS after running migrate_public_schema task. This is needed when multiple rake tasks are run in a single command (and therefor memory space)
