### PR TITLE
Reset the column information on all tables in the plan when migrated online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   it being a `DateTime` rather than a `Time`.
 - Renamed file of `Sequent::Test::WorkflowHelpers` to `workflow_helpers`. If you require this file manually you will need to update it's references
 - You now must "tag" specs using `Sequent::Test::WorkflowHelpers` with the following metadata `workflows: true` to avoid collision with other specs
+- Bugfix: `rake sequent:migrate:online` will now call `reset_column_information` when done. Otherwise a subsequent `sequent:migrate:offline` called in the same memory space fails.
 
 # Changelog 5.0.0 (changes since 4.3.0)
 

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -189,6 +189,8 @@ module Sequent
       #   These tables will be called `table_name_VERSION`.
       # 3. Replay all events to populate the tables
       #   It keeps track of all events that are already replayed.
+      # 4. Resets the table names of the activerecord models (projections)
+      #   back to their original values (so without the VERSION suffix)
       #
       # If anything fails an exception is raised and everything is rolled back
       #
@@ -209,6 +211,7 @@ module Sequent
         in_view_schema do
           executor.create_indexes_after_execute_online(plan)
         end
+        executor.reset_table_names(plan)
         # rubocop:disable Lint/RescueException
       rescue Exception => e
         # rubocop:enable Lint/RescueException

--- a/spec/lib/sequent/migrations/view_schema_spec.rb
+++ b/spec/lib/sequent/migrations/view_schema_spec.rb
@@ -171,14 +171,13 @@ describe Sequent::Migrations::ViewSchema do
             MessageSet.new(aggregate_id: message_aggregate_id, sequence_number: 2, message: 'Foobar'),
           ],
         )
-
         migrator.migrate_online
 
-        expect(AccountRecord.table_name).to eq 'account_records_1'
-        expect(AccountRecord.count).to eq 2
+        expect(AccountRecord.table_name).to eq 'account_records'
+        expect(AccountRecord.connection.select_value('select count(*) from account_records_1')).to eq 2
 
-        expect(MessageRecord.table_name).to eq 'message_records_1'
-        expect(MessageRecord.count).to eq 1
+        expect(MessageRecord.table_name).to eq 'message_records'
+        expect(AccountRecord.connection.select_value('select count(*) from message_records_1')).to eq 1
 
         expect(
           Sequent::Migrations::ViewSchema::ReplayedIds.pluck(:event_id),
@@ -214,8 +213,8 @@ describe Sequent::Migrations::ViewSchema do
 
           migrator.migrate_online
 
-          expect(AccountRecord.table_name).to eq 'account_records_1'
-          expect(AccountRecord.count).to eq 2
+          expect(AccountRecord.table_name).to eq 'account_records'
+          expect(AccountRecord.connection.select_value('select count(*) from account_records_1')).to eq 2
 
           expect(MessageRecord.table_name).to eq 'message_records'
           expect(Sequent::ApplicationRecord.connection).to_not have_view_schema_table('message_records_1')
@@ -340,8 +339,8 @@ describe Sequent::Migrations::ViewSchema do
 
         migrator.migrate_online
 
-        expect(AccountRecord.count).to eq(1)
-        expect(MessageRecord.count).to eq(1)
+        expect(AccountRecord.connection.select_value('select count(*) from account_records_1')).to eq(1)
+        expect(MessageRecord.connection.select_value('select count(*) from message_records_1')).to eq(1)
       end
 
       it 'replays events not yet replayed' do


### PR DESCRIPTION
If rake sequent:migrate:offline is called in the same memory space like:
`rake sequent:migrate:online sequent:migrate:offline` it fails.
This scenario is typically done in development environments in which there
is no need for downtime.
