### PR TITLE
Translate custom errors by error_locale_resolver

### DIFF
--- a/lib/sequent/core/command_service.rb
+++ b/lib/sequent/core/command_service.rb
@@ -71,7 +71,9 @@ module Sequent
 
         filters.each { |filter| filter.execute(command) }
 
-        fail CommandNotValid, command unless command.valid?
+        I18n.with_locale(Sequent.configuration.error_locale_resolver.call) do
+          fail CommandNotValid, command unless command.valid?
+        end
 
         parsed_command = command.parse_attrs_to_correct_types
         command_handlers.select do |h|

--- a/spec/lib/sequent/core/command_service_spec.rb
+++ b/spec/lib/sequent/core/command_service_spec.rb
@@ -96,14 +96,14 @@ describe Sequent::Core::CommandService do
   context 'given multiple available locales' do
     before do
       I18n.config.available_locales = %i[en nl]
-      I18n.backend.store_translations(:nl, { errors: { messages: { blank: 'Verplicht veld' } } })
+      I18n.backend.store_translations(:nl, {errors: {messages: {blank: 'Verplicht veld'}}})
     end
 
     context 'ActiveModel validations' do
       it 'raises a CommandNotValid for invalid commands in english' do
         expect { command_service.execute_commands(TestCommandHandler::DummyBaseCommand.new) }.to raise_error(
-         an_instance_of(Sequent::Core::CommandNotValid)
-           .and(having_attributes(errors: { mandatory_string: ["can't be blank"] })),
+          an_instance_of(Sequent::Core::CommandNotValid)
+            .and(having_attributes(errors: {mandatory_string: ["can't be blank"]})),
         )
       end
 
@@ -114,7 +114,7 @@ describe Sequent::Core::CommandService do
         it 'raises a CommandNotValid for invalid commands in dutch' do
           expect { command_service.execute_commands(TestCommandHandler::DummyBaseCommand.new) }.to raise_error(
             an_instance_of(Sequent::Core::CommandNotValid)
-              .and(having_attributes(errors: { mandatory_string: ['Verplicht veld'] })),
+              .and(having_attributes(errors: {mandatory_string: ['Verplicht veld']})),
           )
         end
       end
@@ -124,7 +124,7 @@ describe Sequent::Core::CommandService do
       it 'raises a CommandNotValid for invalid commands in english' do
         expect { command_service.execute_commands(TestCommandHandler::CustomValidationCommand.new) }.to raise_error(
           an_instance_of(Sequent::Core::CommandNotValid)
-            .and(having_attributes(errors: { mandatory_string: ["can't be blank"] })),
+            .and(having_attributes(errors: {mandatory_string: ["can't be blank"]})),
         )
       end
 
@@ -135,7 +135,7 @@ describe Sequent::Core::CommandService do
         it 'raises a CommandNotValid for invalid commands in dutch' do
           expect { command_service.execute_commands(TestCommandHandler::CustomValidationCommand.new) }.to raise_error(
             an_instance_of(Sequent::Core::CommandNotValid)
-              .and(having_attributes(errors: { mandatory_string: ['Verplicht veld'] })),
+              .and(having_attributes(errors: {mandatory_string: ['Verplicht veld']})),
           )
         end
       end


### PR DESCRIPTION
`command.valid?` fills the error messages. So wrapping that with `I18n.with_locale` ensures those messages are translated according to the `error_locale_resolver`.

Previously tried to ensure this through a command_middleware, like: 

```ruby
class EnsureCommandErrorLocale
  def self.call(command, &block)
    I18n.with_locale(Sequent.configuration.error_locale_resolver&.call || I18n.locale) do
      command.valid?
    end

    block.call
  end
end
```

But the `command.valid?` called in `Sequent::Core::CommandService#process_command` will override the messages again, reverting it back to the default `I18n.locale`. Hence this PR.