### PR TITLE
handle invalid migration definition gracefully

### DIFF
--- a/lib/sequent/migrations/errors.rb
+++ b/lib/sequent/migrations/errors.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Sequent
+  module Migrations
+    class MigrationError < RuntimeError; end
+    class MigrationNotStarted < MigrationError; end
+    class MigrationDone < MigrationError; end
+    class ConcurrentMigration < MigrationError; end
+
+  end
+end

--- a/lib/sequent/migrations/errors.rb
+++ b/lib/sequent/migrations/errors.rb
@@ -7,5 +7,6 @@ module Sequent
     class MigrationDone < MigrationError; end
     class ConcurrentMigration < MigrationError; end
 
+    class InvalidMigrationDefinition < MigrationError; end
   end
 end

--- a/lib/sequent/migrations/planner.rb
+++ b/lib/sequent/migrations/planner.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+
 module Sequent
   module Migrations
     class Planner

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -188,6 +188,7 @@ module Sequent
       #
       # @raise ConcurrentMigrationError if migration is already running
       def migrate_online
+        ensure_valid_plan!
         migrate_metadata_tables
 
         return if Sequent.new_version == current_version
@@ -215,6 +216,9 @@ module Sequent
         Sequent.logger.info("Done migrate_online for version #{Sequent.new_version}")
       rescue ConcurrentMigration
         # Do not rollback the migration when this is a concurrent migration as the other one is running
+        raise
+      rescue InvalidMigrationDefinition
+        # Do not rollback the migration when since there is nothing to rollback
         raise
       rescue Exception => e # rubocop:disable Lint/RescueException
         rollback_migration
@@ -280,6 +284,10 @@ module Sequent
       end
 
       private
+
+      def ensure_valid_plan!
+        plan
+      end
 
       def migrate_metadata_tables
         Sequent::ApplicationRecord.transaction do

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -3,6 +3,7 @@
 require 'parallel'
 require 'postgresql_cursor'
 
+require_relative 'errors'
 require_relative '../support/database'
 require_relative '../sequent'
 require_relative '../util/timer'
@@ -16,10 +17,6 @@ require_relative 'replayed_ids'
 
 module Sequent
   module Migrations
-    class MigrationError < RuntimeError; end
-    class MigrationNotStarted < MigrationError; end
-    class MigrationDone < MigrationError; end
-    class ConcurrentMigration < MigrationError; end
 
     ##
     # ViewSchema is used for migration of you view_schema. For instance

--- a/spec/lib/sequent/migrations/view_schema_spec.rb
+++ b/spec/lib/sequent/migrations/view_schema_spec.rb
@@ -593,6 +593,18 @@ describe Sequent::Migrations::ViewSchema do
             expect(AccountRecord).to have_column('foobar')
           end
         end
+
+        it 'missing the correct alter table file' do
+          expect(MessageRecord).to_not have_column('foobar')
+          Sequent.configuration.migration_sql_files_directory = 'spec/fixtures/db/2'
+          SpecMigrations.copy_and_add('3', [Sequent::Migrations.alter_table(MessageRecord)])
+          SpecMigrations.version = 3
+          expect(next_migration).to_not receive(:replay!)
+
+          expect { next_migration.migrate_online }.to raise_error(Sequent::Migrations::InvalidMigrationDefinition)
+
+          expect(Sequent::Migrations::Versions.where(version: 3).first).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
- Move errors to own file
- Validate plan before starting migration to avoid lingering state
