### PR TITLE
Replay optimized postgres persistor fixes

### DIFF
--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -81,7 +81,7 @@ module Sequent
             end
 
             @index = {}
-            @reverse_index = {}
+            @reverse_index = {}.compare_by_identity
           end
 
           def add(record_class, record)
@@ -91,15 +91,15 @@ module Sequent
               @index[key] = [] unless @index.key? key
               @index[key] << record
 
-              @reverse_index[record.object_id] = [] unless @reverse_index.key? record.object_id
-              @reverse_index[record.object_id] << key
+              @reverse_index[record] = [] unless @reverse_index.key? record
+              @reverse_index[record] << key
             end
           end
 
           def remove(record_class, record)
             return unless indexed?(record_class)
 
-            keys = @reverse_index.delete(record.object_id) { [] }
+            keys = @reverse_index.delete(record) { [] }
 
             return unless keys.any?
 

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -124,8 +124,8 @@ module Sequent
           end
 
           def clear
-            @index = {}
-            @reverse_index = {}
+            @index.clear
+            @reverse_index.clear
           end
 
           def use_index?(record_class, where_clause)

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -88,18 +88,18 @@ module Sequent
             return unless indexed?(record_class)
 
             get_keys(record_class, record).each do |key|
-              @index[key.hash] = [] unless @index.key? key.hash
-              @index[key.hash] << record
+              @index[key] = [] unless @index.key? key
+              @index[key] << record
 
-              @reverse_index[record.object_id.hash] = [] unless @reverse_index.key? record.object_id.hash
-              @reverse_index[record.object_id.hash] << key.hash
+              @reverse_index[record.object_id] = [] unless @reverse_index.key? record.object_id
+              @reverse_index[record.object_id] << key
             end
           end
 
           def remove(record_class, record)
             return unless indexed?(record_class)
 
-            keys = @reverse_index.delete(record.object_id.hash) { [] }
+            keys = @reverse_index.delete(record.object_id) { [] }
 
             return unless keys.any?
 
@@ -120,7 +120,7 @@ module Sequent
               key << field
               key << where_clause.stringify_keys[field]
             end
-            @index[key.hash] || []
+            @index[key] || []
           end
 
           def clear

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -287,23 +287,18 @@ module Sequent
         end
 
         def find_records(record_class, where_clause)
-          found_in_index = @record_index.find(record_class, where_clause)
-          if found_in_index
-            found_in_index
-          else
-            @record_store[record_class].select do |record|
-              where_clause.all? do |k, v|
-                expected_value = v.is_a?(Symbol) ? v.to_s : v
-                actual_value = record[k.to_sym]
-                actual_value = actual_value.to_s if actual_value.is_a? Symbol
-                if expected_value.is_a?(Array)
-                  expected_value.include?(actual_value)
-                else
-                  actual_value == expected_value
-                end
+          (@record_index.find(record_class, where_clause) || @record_store[record_class].select do |record|
+            where_clause.all? do |k, v|
+              expected_value = v.is_a?(Symbol) ? v.to_s : v
+              actual_value = record[k.to_sym]
+              actual_value = actual_value.to_s if actual_value.is_a? Symbol
+              if expected_value.is_a?(Array)
+                expected_value.include?(actual_value)
+              else
+                actual_value == expected_value
               end
             end
-          end.dup
+          end).dup
         end
 
         def last_record(record_class, where_clause)

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -101,7 +101,7 @@ module Sequent
             end
 
             indexed_columns.each do |record_class, indexes|
-              fields = indexes.flatten(1).map { |field| Persistors.normalize_symbols(field) }.to_set
+              fields = indexes.flatten(1).map(&:to_sym).to_set
               @indexed_columns[record_class] = (fields + default_indexes(record_class))
             end
 
@@ -143,7 +143,7 @@ module Sequent
             indexes = get_indexes(record_class, where_clause)
             return nil unless indexes.present?
 
-            normalized_where_clause = where_clause.transform_keys { |k| Persistors.normalize_symbols(k) }
+            normalized_where_clause = where_clause.symbolize_keys
             record_sets = indexes.flat_map do |field|
               if !normalized_where_clause.include? field
                 []
@@ -182,12 +182,12 @@ module Sequent
           end
 
           def get_indexes(record_class, where_clause)
-            fields = where_clause.keys.map { |k| Persistors.normalize_symbols(k) }.to_set
+            fields = where_clause.keys.map(&:to_sym).to_set
             fields & @indexed_columns[record_class]
           end
 
           def default_indexes(record_class)
-            Set['aggregate_id'] & record_class.column_names.to_set
+            Set[:aggregate_id] & record_class.column_names.map(&:to_sym).to_set
           end
         end
 

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -78,7 +78,7 @@ module Sequent
           end
         end
 
-        def self.struct_cache
+        def struct_cache
           @struct_cache ||= Hash.new do |hash, record_class|
             struct_class = Struct.new(*record_class.column_names.map(&:to_sym))
             struct_class.include InMemoryStruct
@@ -207,7 +207,7 @@ module Sequent
           column_names = record_class.column_names
           values = record_class.column_defaults.with_indifferent_access.merge(values)
           values.merge!(updated_at: values[:created_at]) if column_names.include?('updated_at')
-          record = self.class.struct_cache[record_class].new.set_values(values)
+          record = struct_cache[record_class].new.set_values(values)
 
           yield record if block_given?
 

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -118,11 +118,8 @@ module Sequent
             index = get_index(record_class, where_clause)
             return nil unless index
 
-            key = [record_class.name]
-            index.each do |field|
-              key << field
-              key << where_clause.stringify_keys[field]
-            end
+            normalized_where_clause = where_clause.stringify_keys
+            key = [record_class.name, index] + index.map { |field| normalized_where_clause[field] }
             @index[key] || []
           end
 
@@ -146,12 +143,7 @@ module Sequent
 
           def get_keys(record_class, record)
             @indexed_columns[record_class].map do |index|
-              arr = [record_class.name]
-              index.each do |key|
-                arr << key
-                arr << record[key]
-              end
-              arr
+              [record_class.name, index] + index.map { |field| record[field] }
             end
           end
 

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -57,9 +57,13 @@ module Sequent
         attr_accessor :insert_with_csv_size
 
         # We create a struct on the fly to represent an in-memory record.
+        #
         # Since the replay happens in memory we implement the ==, eql? and hash methods
         # to point to the same object. A record is the same if and only if they point to
         # the same object. These methods are necessary since we use Set instead of [].
+        #
+        # Also basing equality on object identity is more consistent with ActiveRecord,
+        # which is the implementation used during normal (non-optimized) replay.
         module InMemoryStruct
           def ==(other)
             equal?(other)

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -515,7 +515,7 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
         context 'multi-colum indexes' do
           let(:indices) { [%i[command_record_id id]] }
           it 'should split to single-attribute indexes for backwards compatibility' do
-            expect(index.instance_variable_get(:@indexed_columns)[Sequent::Core::EventRecord])
+            expect(index.indexed_columns(Sequent::Core::EventRecord))
               .to match_array %i[aggregate_id command_record_id id]
           end
         end
@@ -523,7 +523,7 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
         context 'duplicate indexes' do
           let(:indices) { %i[aggregate_id command_record_id id id command_record_id] }
           it 'are removed' do
-            expect(index.instance_variable_get(:@indexed_columns)[Sequent::Core::EventRecord])
+            expect(index.indexed_columns(Sequent::Core::EventRecord))
               .to match_array %i[aggregate_id command_record_id id]
           end
         end

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -427,6 +427,27 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
           expect(index.use_index?(Sequent::Core::EventRecord, {sequence_number: 1})).to be_falsey
           expect(index.use_index?(Sequent::Core::EventRecord, {id: 1, sequence_number: 1})).to be_falsey
         end
+
+        context 'duplicate indexes' do
+          let(:indices) { [[:aggregate_id], [:command_record_id, :id], [:id, :command_record_id]] }
+          it 'are removed' do
+            expect(index.instance_variable_get(:@indexed_columns)[Sequent::Core::EventRecord])
+              .to match_array [['aggregate_id'], ['command_record_id', 'id']]
+          end
+        end
+      end
+
+      context 'default index when record class is specified' do
+        it 'adds a default index for aggregate_id' do
+          expect(index.use_index?(Sequent::Core::EventRecord, {aggregate_id: 1})).to be_truthy
+        end
+      end
+
+      context 'default index when record class is not specified' do
+        let(:index) { Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor::Index.new({}) }
+        it 'adds a default index for aggregate_id' do
+          expect(index.use_index?(Sequent::Core::EventRecord, {aggregate_id: 1})).to be_truthy
+        end
       end
 
       context 'where clause order' do

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -12,7 +12,7 @@ class MockEvent < Sequent::Core::Event
   end
 end
 
-def measure_elapsed_time &block
+def measure_elapsed_time(&block)
   starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
   yield block
   ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -402,7 +402,10 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
 
     before do
       aggregate_ids.each_with_index do |aggregate_id, i|
-        persistor.create_record(Sequent::Core::EventRecord, {id: i, aggregate_id: aggregate_id, command_record_id: i * 7})
+        persistor.create_record(
+          Sequent::Core::EventRecord,
+          {id: i, aggregate_id: aggregate_id, command_record_id: i * 7},
+        )
       end
     end
 
@@ -427,7 +430,6 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
       end
       expect(elapsed).to be <= MAX_TIME_S
     end
-
   end
 
   describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor::Index do
@@ -481,10 +483,10 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
         end
 
         context 'duplicate indexes' do
-          let(:indices) { [[:aggregate_id], [:command_record_id, :id], [:id, :command_record_id]] }
+          let(:indices) { [%i[aggregate_id], %i[command_record_id id], %i[id command_record_id]] }
           it 'are removed' do
             expect(index.instance_variable_get(:@indexed_columns)[Sequent::Core::EventRecord])
-              .to match_array [['aggregate_id'], ['command_record_id', 'id']]
+              .to match_array [['aggregate_id'], %w[command_record_id id]]
           end
         end
       end

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -531,7 +531,7 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
           let(:indices) { [%i[command_record_id id]] }
           it 'should split to single-attribute indexes for backwards compatibility' do
             expect(index.instance_variable_get(:@indexed_columns)[Sequent::Core::EventRecord])
-              .to match_array %w[aggregate_id command_record_id id]
+              .to match_array %i[aggregate_id command_record_id id]
           end
         end
 
@@ -539,7 +539,7 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
           let(:indices) { %i[aggregate_id command_record_id id id command_record_id] }
           it 'are removed' do
             expect(index.instance_variable_get(:@indexed_columns)[Sequent::Core::EventRecord])
-              .to match_array %w[aggregate_id command_record_id id]
+              .to match_array %i[aggregate_id command_record_id id]
           end
         end
       end

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -490,26 +490,11 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
     describe '#use_index?' do
       context 'symbolized single indices' do
         let(:indices) { [:id] }
-        it 'uses the index for strings and symbols where clause' do
+        it 'uses the index for simple indexed column' do
           expect(index.use_index?(Sequent::Core::EventRecord, {id: 1})).to be_truthy
-          expect(index.use_index?(Sequent::Core::EventRecord, {'id' => 1})).to be_truthy
         end
 
         it 'does not use index for non indexed columns' do
-          expect(index.use_index?(Sequent::Core::EventRecord, {'command_record_id' => 1})).to be_falsey
-          expect(index.use_index?(Sequent::Core::EventRecord, {command_record_id: 1})).to be_falsey
-        end
-      end
-
-      context 'string single indices' do
-        let(:indices) { ['id'] }
-        it 'uses the index for strings and symbols where clause' do
-          expect(index.use_index?(Sequent::Core::EventRecord, {id: 1})).to be_truthy
-          expect(index.use_index?(Sequent::Core::EventRecord, {'id' => 1})).to be_truthy
-        end
-
-        it 'does not use index for non indexed columns' do
-          expect(index.use_index?(Sequent::Core::EventRecord, {'command_record_id' => 1})).to be_falsey
           expect(index.use_index?(Sequent::Core::EventRecord, {command_record_id: 1})).to be_falsey
         end
       end
@@ -517,9 +502,9 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
       context 'multiple indices' do
         let(:indices) { %w[id command_record_id] }
 
-        it 'uses the index for strings and symbols where clause' do
+        it 'uses the index for where clause' do
           expect(index.use_index?(Sequent::Core::EventRecord, {id: 1})).to be_truthy
-          expect(index.use_index?(Sequent::Core::EventRecord, {'id' => 1, command_record_id: 10})).to be_truthy
+          expect(index.use_index?(Sequent::Core::EventRecord, {command_record_id: 10})).to be_truthy
         end
 
         it 'use index for for partial indexed where clauses' do

--- a/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
+++ b/spec/lib/sequent/core/persistors/replay_optimized_postgres_persistor_spec.rb
@@ -86,49 +86,49 @@ describe Sequent::Core::Persistors::ReplayOptimizedPostgresPersistor do
         object = persistor.get_record!(record_class, {id: 1})
         expect(object.id).to eq 1
       end
+    end
 
-      context '#get_record' do
-        it 'returns the object' do
-          object = persistor.get_record(record_class, {id: 1})
-          expect(object.id).to eq 1
-        end
+    context '#get_record' do
+      it 'returns the object' do
+        object = persistor.get_record(record_class, {id: 1})
+        expect(object.id).to eq 1
       end
+    end
 
-      context '#find_records' do
-        it 'returns the object' do
-          objects = persistor.find_records(record_class, {id: 1})
-          expect(objects).to have(1).item
-          expect(objects.first.id).to eq 1
-        end
+    context '#find_records' do
+      it 'returns the object' do
+        objects = persistor.find_records(record_class, {id: 1})
+        expect(objects).to have(1).item
+        expect(objects.first.id).to eq 1
       end
+    end
 
-      context '#delete_all_records' do
-        it 'deletes the object' do
-          persistor.delete_all_records(record_class, {id: 1})
+    context '#delete_all_records' do
+      it 'deletes the object' do
+        persistor.delete_all_records(record_class, {id: 1})
 
-          objects = persistor.find_records(record_class, {id: 1})
-          expect(objects).to be_empty
-        end
+        objects = persistor.find_records(record_class, {id: 1})
+        expect(objects).to be_empty
       end
+    end
 
-      context '#delete_record' do
-        it 'deletes the object' do
-          objects = persistor.find_records(record_class, {id: 1})
-          persistor.delete_record(record_class, objects.first)
+    context '#delete_record' do
+      it 'deletes the object' do
+        objects = persistor.find_records(record_class, {id: 1})
+        persistor.delete_record(record_class, objects.first)
 
-          expect(persistor.find_records(record_class, {id: 1})).to be_empty
-        end
+        expect(persistor.find_records(record_class, {id: 1})).to be_empty
       end
+    end
 
-      context '#update_all_records' do
-        it 'updates the records' do
-          persistor.update_all_records(record_class, {id: 1}, {sequence_number: 3})
+    context '#update_all_records' do
+      it 'updates the records' do
+        persistor.update_all_records(record_class, {id: 1}, {sequence_number: 3})
 
-          objects = persistor.find_records(record_class, {id: 1})
-          expect(objects).to have(1).item
-          expect(objects.first.id).to eq 1
-          expect(objects.first.sequence_number).to eq 3
-        end
+        objects = persistor.find_records(record_class, {id: 1})
+        expect(objects).to have(1).item
+        expect(objects.first.id).to eq 1
+        expect(objects.first.sequence_number).to eq 3
       end
     end
   end


### PR DESCRIPTION
This fixes two problems in the `ReplayOptimizedPostgresPersistor`:

1. The documentation specifies that a default `aggregate_id` index is automatically added. Unfortunately the implementation was broken.
2. The index used the `hash` value of the record keys but did not handle hash collisions at all. So when the hash function collided records could be affected with different keys, causing data corruption.

This PR fixes both issues and (tries to) clean up the code.