### PR TITLE
Add migrate:dryrun task for performance testing of projectors

### DIFF
--- a/lib/sequent.rb
+++ b/lib/sequent.rb
@@ -5,5 +5,6 @@ require_relative 'sequent/sequent'
 require_relative 'sequent/core/core'
 require_relative 'sequent/util/util'
 require_relative 'sequent/migrations/migrations'
+require_relative 'sequent/dry_run/dry_run'
 
 require_relative 'notices'

--- a/lib/sequent/core/persistors/active_record_persistor.rb
+++ b/lib/sequent/core/persistors/active_record_persistor.rb
@@ -117,6 +117,10 @@ module Sequent
           Sequent::ApplicationRecord.connection.execute(statement)
         end
 
+        def prepare
+          # noop
+        end
+
         def commit
           # noop
         end

--- a/lib/sequent/core/persistors/persistor.rb
+++ b/lib/sequent/core/persistors/persistor.rb
@@ -77,6 +77,11 @@ module Sequent
         end
 
         # Hook to implement for instance the persistor batches statements
+        def prepare
+          fail 'Method not supported in this persistor'
+        end
+
+        # Hook to implement for instance the persistor batches statements
         def commit
           fail 'Method not supported in this persistor'
         end

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -311,6 +311,7 @@ module Sequent
         end
 
         def prepare
+          # noop
         end
 
         def commit

--- a/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/core/persistors/replay_optimized_postgres_persistor.rb
@@ -310,6 +310,9 @@ module Sequent
           results.empty? ? nil : results.last
         end
 
+        def prepare
+        end
+
         def commit
           @record_store.each do |clazz, records|
             @column_cache ||= {}

--- a/lib/sequent/dry_run/dry_run.rb
+++ b/lib/sequent/dry_run/dry_run.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require_relative 'read_only_replay_optimized_postgres_persistor'
+require_relative 'view_schema'

--- a/lib/sequent/dry_run/read_only_replay_optimized_postgres_persistor.rb
+++ b/lib/sequent/dry_run/read_only_replay_optimized_postgres_persistor.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative '../core/persistors/replay_optimized_postgres_persistor'
+module Sequent
+  module DryRun
+    # Subclass of ReplayOptimizedPostgresPersistor
+    # This persistor does not persist anything. Mainly usefull for
+    # performance testing migrations.
+    class ReadOnlyReplayOptimizedPostgresPersistor < Core::Persistors::ReplayOptimizedPostgresPersistor
+      def prepare
+        @starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
+      def commit
+        # Running in dryrun mode, not committing anything.
+        ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        elapsed = ending - @starting
+        count = @record_store.values.map(&:size).sum
+        Sequent.logger.info(
+          "dryrun: processed #{count} records in #{elapsed.round(2)} s (#{(count / elapsed).round(2)} records/s)",
+        )
+        clear
+      end
+    end
+  end
+end

--- a/lib/sequent/dry_run/view_schema.rb
+++ b/lib/sequent/dry_run/view_schema.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require_relative '../migrations/view_schema'
+require_relative 'read_only_replay_optimized_postgres_persistor'
+
+module Sequent
+  module DryRun
+    # Subclass of Migrations::ViewSchema to dry run a migration.
+    # This migration does not insert anything into the database, mainly usefull
+    # for performance testing migrations.
+    class ViewSchema < Migrations::ViewSchema
+      def migrate_dryrun(regex:, group_exponent: 3, limit: nil, offset: nil)
+        persistor = DryRun::ReadOnlyReplayOptimizedPostgresPersistor.new
+
+        projectors = Sequent::Core::Migratable.all.select { |p| p.replay_persistor.nil? && p.name.match(regex || /.*/) }
+        if projectors.present?
+          Sequent.logger.info "Dry run using the following projectors: #{projectors.map(&:name).join(', ')}"
+
+          starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          groups = groups(group_exponent: group_exponent, limit: limit, offset: offset)
+          replay!(persistor, projectors: projectors, groups: groups)
+          ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+          Sequent.logger.info("Done migrate_dryrun for version #{Sequent.new_version} in #{ending - starting} s")
+        end
+      end
+
+      private
+
+      # override so no ids are inserted.
+      def insert_ids
+        ->(progress, done, ids) {}
+      end
+    end
+  end
+end

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -291,12 +291,12 @@ module Sequent
         persistor = Sequent.configuration.online_replay_persistor_class.new
         persistor.define_singleton_method(:commit) do
           # Running in dryrun mode, not committing anything.
-          puts "Dryrun: would have committed #{@record_store.values.map(&:size).sum} records"
+          Sequent.logger.info "Dryrun: would have committed #{@record_store.values.map(&:size).sum} records"
           clear
         end
 
         projectors = Sequent::Core::Migratable.all.select { |p| p.replay_persistor.nil? && p.name.match(regex || /.*/) }
-        puts "Dry run using the following projectors: #{projectors.map(&:name).join(', ')}"
+        Sequent.logger.info "Dry run using the following projectors: #{projectors.map(&:name).join(', ')}"
 
         replay!(persistor, projectors: projectors, group_exponent: group_exponent, limit: limit, offset: offset) if projectors.any?
 

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -354,7 +354,7 @@ module Sequent
             # using `map_with_index` because https://github.com/grosser/parallel/issues/175
             result = Parallel.map_with_index(
               groups,
-              in_processes: Sequent.configuration.number_of_replay_processes,
+              in_processes: ENV["WORKERS"]&.to_i || Sequent.configuration.number_of_replay_processes,
             ) do |aggregate_prefixes, index|
               @connected ||= establish_connection
               msg = <<~EOS.chomp

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -156,7 +156,12 @@ module Sequent
               db_config = Sequent::Support::Database.read_config(@env)
               view_schema = Sequent::Migrations::ViewSchema.new(db_config: db_config)
 
-              view_schema.migrate_dryrun(args[:regex], (args[:group_exponent] || 3).to_i, args[:limit]&.to_i, args[:offset]&.to_i)
+              view_schema.migrate_dryrun(
+                regex: args[:regex],
+                group_exponent: (args[:group_exponent] || 3).to_i,
+                limit: args[:limit]&.to_i,
+                offset: args[:offset]&.to_i,
+              )
             end
           end
 

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -150,13 +150,13 @@ module Sequent
 
               Pass a regular expression as parameter to select the projectors to run, otherwise all projectors are selected.
             EOS
-            task :dryrun, %i[regex group_exponent] => ['sequent:init', :init] do |_task, args|
+            task :dryrun, %i[regex group_exponent limit offset] => ['sequent:init', :init] do |_task, args|
               ensure_sequent_env_set!
 
               db_config = Sequent::Support::Database.read_config(@env)
               view_schema = Sequent::Migrations::ViewSchema.new(db_config: db_config)
 
-              view_schema.migrate_dryrun(args[:regex], (args[:group_exponent] || 3).to_i)
+              view_schema.migrate_dryrun(args[:regex], (args[:group_exponent] || 3).to_i, args[:limit]&.to_i, args[:offset]&.to_i)
             end
           end
 

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -154,7 +154,7 @@ module Sequent
               ensure_sequent_env_set!
 
               db_config = Sequent::Support::Database.read_config(@env)
-              view_schema = Sequent::Migrations::ViewSchema.new(db_config: db_config)
+              view_schema = Sequent::DryRun::ViewSchema.new(db_config: db_config)
 
               view_schema.migrate_dryrun(
                 regex: args[:regex],

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -144,6 +144,20 @@ module Sequent
 
               view_schema.migrate_offline
             end
+
+            desc <<~EOS
+              Runs the projectors in replay mode without making any changes to the database, useful for (performance) testing against real data.
+
+              Pass a regular expression as parameter to select the projectors to run, otherwise all projectors are selected.
+            EOS
+            task :dryrun, %i[regex group_exponent] => ['sequent:init', :init] do |_task, args|
+              ensure_sequent_env_set!
+
+              db_config = Sequent::Support::Database.read_config(@env)
+              view_schema = Sequent::Migrations::ViewSchema.new(db_config: db_config)
+
+              view_schema.migrate_dryrun(args[:regex], (args[:group_exponent] || 3).to_i)
+            end
           end
 
           namespace :snapshots do


### PR DESCRIPTION
This task replays all events for the selected projectors without persisting any results (so it works with a PostgreSQL read-only session).