### PR TITLE
add xact_id to the event_records table when generating a sequent project

### DIFF
--- a/lib/sequent/generator/template_project/db/sequent_schema.rb
+++ b/lib/sequent/generator/template_project/db/sequent_schema.rb
@@ -8,6 +8,7 @@ ActiveRecord::Schema.define do
     t.text "event_json", :null => false
     t.integer "command_record_id", :null => false
     t.integer "stream_record_id", :null => false
+    t.bigint "xact_id"
   end
 
   execute %Q{


### PR DESCRIPTION
while following `docs/docs/getting-started.md` this was causing `bundle exec rake sequent:migrate:online` to fail

```
...
E, [2024-03-01T12:13:29.239226 #44644] ERROR -- : +++++++++++++++ ERROR +++++++++++++++
E, [2024-03-01T12:13:29.239265 #44643] ERROR -- : +++++++++++++++ ERROR +++++++++++++++
E, [2024-03-01T12:13:29.239375 #44644] ERROR -- : PG::UndefinedColumn: ERROR:  column "xact_id" does not exist
LINE 2: ) AND (xact_id IS NULL OR xact_id < 2254234) ORDER BY aggreg...
```