### PR TITLE
Relax parser version to allow the latest Rubocop version

### DIFF
--- a/gemfiles/ar_6_0.gemfile.lock
+++ b/gemfiles/ar_6_0.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       i18n
       oj (~> 3)
       parallel (~> 1.20)
-      parser (>= 2.6.5, < 3.3)
+      parser (>= 2.6.5, < 3.4)
       pg (~> 1.2)
       postgresql_cursor (~> 0.6)
       thread_safe (~> 0.3.6)
@@ -100,6 +100,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/ar_6_1.gemfile.lock
+++ b/gemfiles/ar_6_1.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       i18n
       oj (~> 3)
       parallel (~> 1.20)
-      parser (>= 2.6.5, < 3.3)
+      parser (>= 2.6.5, < 3.4)
       pg (~> 1.2)
       postgresql_cursor (~> 0.6)
       thread_safe (~> 0.3.6)
@@ -100,6 +100,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/ar_7_0.gemfile.lock
+++ b/gemfiles/ar_7_0.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       i18n
       oj (~> 3)
       parallel (~> 1.20)
-      parser (>= 2.6.5, < 3.3)
+      parser (>= 2.6.5, < 3.4)
       pg (~> 1.2)
       postgresql_cursor (~> 0.6)
       thread_safe (~> 0.3.6)
@@ -98,6 +98,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/gemfiles/ar_7_1.gemfile.lock
+++ b/gemfiles/ar_7_1.gemfile.lock
@@ -8,7 +8,7 @@ PATH
       i18n
       oj (~> 3)
       parallel (~> 1.20)
-      parser (>= 2.6.5, < 3.3)
+      parser (>= 2.6.5, < 3.4)
       pg (~> 1.2)
       postgresql_cursor (~> 0.6)
       thread_safe (~> 0.3.6)
@@ -112,6 +112,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n'
   s.add_dependency 'oj', '~> 3'
   s.add_dependency 'parallel', '~> 1.20'
-  s.add_dependency 'parser', '>= 2.6.5', '< 3.3'
+  s.add_dependency 'parser', '>= 2.6.5', '< 3.4'
   s.add_dependency 'pg', '~> 1.2'
   s.add_dependency 'postgresql_cursor', '~> 0.6'
   s.add_dependency 'thread_safe', '~> 0.3.6'


### PR DESCRIPTION
Similar to what we've seen on https://github.com/zilverline/sequent/issues/268 and https://github.com/zilverline/sequent/pull/374