### PR TITLE
Register types rake task

### DIFF
--- a/db/migrate/20250220161400_sequent_register_types.rb
+++ b/db/migrate/20250220161400_sequent_register_types.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class SequentRegisterTypes < ActiveRecord::Migration[7.2]
+  def up
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute_sql_file 'register_types', version: 1
+    end
+  end
+
+  def down
+    fail ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def execute_sql_file(filename, version:)
+    say "Applying '#{filename}' version #{version}", true
+    suppress_messages do
+      execute File.read(
+        File.join(
+          File.dirname(__FILE__),
+          format('sequent/%s_v%02d.sql', filename, version),
+        ),
+      )
+    end
+  end
+end

--- a/db/migrate/20250509120000_sequent_register_types.rb
+++ b/db/migrate/20250509120000_sequent_register_types.rb
@@ -8,7 +8,9 @@ class SequentRegisterTypes < ActiveRecord::Migration[7.2]
   end
 
   def down
-    fail ActiveRecord::IrreversibleMigration
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute 'DROP PROCEDURE IF EXISTS register_types(_types jsonb)'
+    end
   end
 
   private

--- a/db/migrate/sequent/register_types_v01.sql
+++ b/db/migrate/sequent/register_types_v01.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE PROCEDURE register_types(_types jsonb)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+BEGIN
+  WITH types AS (
+    SELECT DISTINCT type
+      FROM jsonb_array_elements_text(_types->'command_types') AS type
+    EXCEPT
+    SELECT type FROM command_types
+  )
+  INSERT INTO command_types (type)
+  SELECT type FROM types
+   ORDER BY 1
+      ON CONFLICT DO NOTHING;
+
+  WITH types AS (
+    SELECT DISTINCT type AS type
+      FROM jsonb_array_elements_text(_types->'aggregate_root_types') AS type
+    EXCEPT
+    SELECT type FROM aggregate_types
+  )
+  INSERT INTO aggregate_types (type)
+  SELECT type FROM types
+   ORDER BY 1
+      ON CONFLICT DO NOTHING;
+
+  WITH types AS (
+    SELECT DISTINCT type AS type
+      FROM jsonb_array_elements_text(_types->'event_types') AS type
+    EXCEPT
+    SELECT type FROM event_types
+  )
+  INSERT INTO event_types (type)
+  SELECT type FROM types
+   ORDER BY 1
+      ON CONFLICT DO NOTHING;
+END;
+$$;

--- a/db/migrate/sequent/register_types_v01.sql
+++ b/db/migrate/sequent/register_types_v01.sql
@@ -14,7 +14,7 @@ BEGIN
 
   WITH types AS (
     SELECT DISTINCT type AS type
-      FROM jsonb_array_elements_text(_types->'aggregate_root_types') AS type
+      FROM jsonb_array_elements_text(_types->'aggregate_types') AS type
     EXCEPT
     SELECT type FROM aggregate_types
   )

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -294,6 +294,51 @@ $$;
 
 
 --
+-- Name: register_types(jsonb); Type: PROCEDURE; Schema: sequent_schema; Owner: -
+--
+
+CREATE PROCEDURE sequent_schema.register_types(IN _types jsonb)
+    LANGUAGE plpgsql
+    SET search_path TO 'sequent_schema'
+    AS $$
+BEGIN
+  WITH types AS (
+    SELECT DISTINCT type
+      FROM jsonb_array_elements_text(_types->'command_types') AS type
+    EXCEPT
+    SELECT type FROM command_types
+  )
+  INSERT INTO command_types (type)
+  SELECT type FROM types
+   ORDER BY 1
+      ON CONFLICT DO NOTHING;
+
+  WITH types AS (
+    SELECT DISTINCT type AS type
+      FROM jsonb_array_elements_text(_types->'aggregate_root_types') AS type
+    EXCEPT
+    SELECT type FROM aggregate_types
+  )
+  INSERT INTO aggregate_types (type)
+  SELECT type FROM types
+   ORDER BY 1
+      ON CONFLICT DO NOTHING;
+
+  WITH types AS (
+    SELECT DISTINCT type AS type
+      FROM jsonb_array_elements_text(_types->'event_types') AS type
+    EXCEPT
+    SELECT type FROM event_types
+  )
+  INSERT INTO event_types (type)
+  SELECT type FROM types
+   ORDER BY 1
+      ON CONFLICT DO NOTHING;
+END;
+$$;
+
+
+--
 -- Name: save_events_on_delete_trigger(); Type: FUNCTION; Schema: sequent_schema; Owner: -
 --
 
@@ -1389,6 +1434,7 @@ SET search_path TO public, view_schema, sequent_schema;
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250501120000'),
 ('20250312105100'),
+('20250220161400'),
 ('20250101000001'),
 ('20250101000000');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -315,7 +315,7 @@ BEGIN
 
   WITH types AS (
     SELECT DISTINCT type AS type
-      FROM jsonb_array_elements_text(_types->'aggregate_root_types') AS type
+      FROM jsonb_array_elements_text(_types->'aggregate_types') AS type
     EXCEPT
     SELECT type FROM aggregate_types
   )

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1432,9 +1432,9 @@ ALTER TABLE ONLY sequent_schema.snapshot_records
 SET search_path TO public, view_schema, sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250509120000'),
 ('20250501120000'),
 ('20250312105100'),
-('20250220161400'),
 ('20250101000001'),
 ('20250101000000');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1429,7 +1429,7 @@ ALTER TABLE ONLY sequent_schema.snapshot_records
 -- PostgreSQL database dump complete
 --
 
-SET search_path TO public, view_schema, sequent_schema;
+SET search_path TO public,view_schema,sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250509120000'),

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -53,6 +53,20 @@ module Sequent
         end
       end
 
+      def register_types(aggregate_root_classes: [], command_classes: [], event_classes: [])
+        call_procedure(
+          connection,
+          'register_types',
+          [
+            {
+              aggregate_root_types: aggregate_root_classes.map(&:name),
+              command_types: command_classes.map(&:name),
+              event_types: event_classes.map(&:name),
+            }.to_json,
+          ],
+        )
+      end
+
       ##
       # Stores the events in the EventStore and publishes the events
       # to the registered event_handlers.

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -54,7 +54,7 @@ module Sequent
       end
 
       def register_types!(
-        aggregate_root_classes: Sequent::Core::AggregateRoot.descendants,
+        aggregate_classes: Sequent::Core::AggregateRoot.descendants,
         command_classes: Sequent::Core::Command.descendants,
         event_classes: Sequent::Core::Event.descendants
       )
@@ -63,7 +63,7 @@ module Sequent
           'register_types',
           [
             {
-              aggregate_root_types: aggregate_root_classes.map(&:name),
+              aggregate_root_types: aggregate_classes.map(&:name),
               command_types: command_classes.map(&:name),
               event_types: event_classes.map(&:name),
             }.to_json,

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -53,7 +53,11 @@ module Sequent
         end
       end
 
-      def register_types(aggregate_root_classes: [], command_classes: [], event_classes: [])
+      def register_types!(
+        aggregate_root_classes: Sequent::Core::AggregateRoot.descendants,
+        command_classes: Sequent::Core::Command.descendants,
+        event_classes: Sequent::Core::Event.descendants
+      )
         call_procedure(
           connection,
           'register_types',

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -48,7 +48,7 @@ module Sequent
               connection
 
               Sequent.configuration.event_store.register_types(
-                aggregate_root_classes: all_subclasses(Sequent::Core::AggregateRoot),
+                aggregate_root_classes: Sequent::Core::AggregateRoot.descendants,
                 command_classes: all_subclasses(Sequent::Core::Command),
                 event_classes: all_subclasses(Sequent::Core::Event),
               )

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -47,11 +47,8 @@ module Sequent
 
               connection
 
-              Sequent.configuration.event_store.register_types(
-                aggregate_root_classes: Sequent::Core::AggregateRoot.descendants,
-                command_classes: all_subclasses(Sequent::Core::Command),
-                event_classes: all_subclasses(Sequent::Core::Event),
-              )
+              Sequent.configuration.event_store.register_types!
+              Sequent.logger.info 'Registered aggregate root, command, and event types'
             end
           end
 
@@ -392,10 +389,6 @@ module Sequent
         @env ||= ENV['SEQUENT_ENV'] || fail('SEQUENT_ENV not set')
       end
       # rubocop:enable Naming/MemoizedInstanceVariableName
-
-      def all_subclasses(parent)
-        ObjectSpace.each_object(Class).select { |klass| klass < parent }
-      end
     end
   end
 end


### PR DESCRIPTION
Adds a new Rake task `sequent:register:types` to insert aggregate root, command, and event types into the `*_types` tables. Useful to run after deploying new code so all new types are registered in advance.