### PR TITLE
Add event store update unique keys method

### DIFF
--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -201,6 +201,39 @@ module Sequent
         ]
       end
 
+      # Returns an enumerator that yields aggregate ids in blocks of `group_size` arrays. Optionally the
+      # aggregate root type can be specified (as a string) to only yield aggregate ids of the indicated type.
+      def event_streams_enumerator(aggregate_root_type: nil, group_size: 100)
+        Enumerator.new do |yielder|
+          last_events_partition_key = ''
+          last_aggregate_id = nil
+          loop do
+            aggregate_rows = ActiveRecord::Base.connection.exec_query(
+              'SELECT events_partition_key, aggregate_id
+                FROM aggregates
+                WHERE ($1::text IS NULL OR aggregate_type_id = (SELECT id FROM aggregate_types WHERE type = $1))
+                AND ((events_partition_key >= $3 AND $4::uuid IS NULL)
+                     OR (events_partition_key, aggregate_id) > ($3, $4))
+                ORDER BY 1, 2
+                LIMIT $2',
+              'aggregates_to_update',
+              [
+                aggregate_root_type,
+                group_size,
+                last_events_partition_key,
+                last_aggregate_id,
+              ],
+            ).to_a
+            break if aggregate_rows.empty?
+
+            last_events_partition_key = aggregate_rows.last['events_partition_key']
+            last_aggregate_id = aggregate_rows.last['aggregate_id']
+
+            yielder << aggregate_rows.map { |x| x['aggregate_id'] }
+          end
+        end
+      end
+
       def update_unique_keys(event_streams)
         fail ArgumentError, 'array of stream records expected' unless event_streams.all? { |x| x.is_a?(EventStream) }
 

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -201,6 +201,18 @@ module Sequent
         ]
       end
 
+      def update_unique_keys(event_streams)
+        fail ArgumentError, 'array of stream records expected' unless event_streams.all? { |x| x.is_a?(EventStream) }
+
+        call_procedure(connection, 'update_unique_keys', [event_streams.to_json])
+      rescue ActiveRecord::RecordNotUnique => e
+        if e.message =~ /duplicate unique key value for aggregate/
+          raise AggregateKeyNotUniqueError, e.message
+        else
+          raise OptimisticLockingError
+        end
+      end
+
       def permanently_delete_event_stream(aggregate_id)
         permanently_delete_event_streams([aggregate_id])
       end

--- a/lib/sequent/core/event_store.rb
+++ b/lib/sequent/core/event_store.rb
@@ -203,7 +203,7 @@ module Sequent
 
       # Returns an enumerator that yields aggregate ids in blocks of `group_size` arrays. Optionally the
       # aggregate root type can be specified (as a string) to only yield aggregate ids of the indicated type.
-      def event_streams_enumerator(aggregate_root_type: nil, group_size: 100)
+      def event_streams_enumerator(aggregate_type: nil, group_size: 100)
         Enumerator.new do |yielder|
           last_events_partition_key = ''
           last_aggregate_id = nil
@@ -218,7 +218,7 @@ module Sequent
                 LIMIT $2',
               'aggregates_to_update',
               [
-                aggregate_root_type,
+                aggregate_type,
                 group_size,
                 last_events_partition_key,
                 last_aggregate_id,

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -254,10 +254,10 @@ module Sequent
               Use this after adding new unique key constraints to an aggregate to ensure every aggregate's unique keys
               are present in the database.
             EOS
-            task :unique_keys, %i[aggregate_root_type group_size] => ['sequent:init', :init] do |_task, args|
+            task :unique_keys, %i[aggregate_type group_size] => ['sequent:init', :init] do |_task, args|
               count = 0
               Sequent.configuration.event_store.event_streams_enumerator(
-                aggregate_root_type: args[:aggregate_root_type],
+                aggregate_type: args[:aggregate_type],
                 group_size: args[:group_size] || 100,
               ).each do |aggregate_ids|
                 Sequent.configuration.transaction_provider.transactional do

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -247,6 +247,28 @@ module Sequent
 
               view_schema.migrate_dryrun(regex: args[:regex])
             end
+
+            desc <<~EOS
+              Loads all aggregates of the specified type (if any) and updates the aggregate's unique keys in the database.
+
+              Use this after adding new unique key constraints to an aggregate to ensure every aggregate's unique keys
+              are present in the database.
+            EOS
+            task :unique_keys, %i[aggregate_root_type group_size] => ['sequent:init', :init] do |_task, args|
+              count = 0
+              Sequent.configuration.event_store.event_streams_enumerator(
+                aggregate_root_type: args[:aggregate_root_type],
+                group_size: args[:group_size] || 100,
+              ).each do |aggregate_ids|
+                Sequent.configuration.transaction_provider.transactional do
+                  aggregates = Sequent.configuration.aggregate_repository.load_aggregates(aggregate_ids)
+                  Sequent.configuration.event_store.update_unique_keys(aggregates.map(&:event_stream))
+                  count += aggregates.size
+                  printf("\rUpdated unique keys for #{count} aggregates.")
+                end
+              end
+              puts("\nDone.")
+            end
           end
 
           namespace :snapshots do

--- a/lib/sequent/test/command_handler_helpers.rb
+++ b/lib/sequent/test/command_handler_helpers.rb
@@ -122,6 +122,15 @@ module Sequent
           [deserialize_events(@stored_events[mark..]), position_mark]
         end
 
+        def event_streams_enumerator(aggregate_type: nil, group_size: 100)
+          @event_streams
+            .values
+            .select { |es| aggregate_type.nil? || es.aggregate_type == aggregate_type }
+            .sort_by { |es| [es.events_partition_key, es.aggregate_id] }
+            .map(&:aggregate_id)
+            .each_slice(group_size)
+        end
+
         private
 
         def serialize_events(events)

--- a/lib/sequent/util/dry_run.rb
+++ b/lib/sequent/util/dry_run.rb
@@ -36,6 +36,10 @@ module Sequent
                  :load_events,
                  :stream_exists?,
                  :events_exists?,
+                 :event_streams_enumerator,
+                 :find_event_stream,
+                 :position_mark,
+                 :load_events_since_marked_position,
                  to: :event_store
 
         def initialize(result, event_store)
@@ -49,6 +53,10 @@ module Sequent
 
           new_events = streams_with_events.flat_map { |_, events| events }
           @result.published_command_with_events(command, new_events)
+        end
+
+        def update_unique_keys(event_streams)
+          # no-op
         end
       end
 

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -433,7 +433,7 @@ describe Sequent::Core::EventStore do
         end
 
         it 'finds all event streams of a specific type' do
-          subject = event_store.event_streams_enumerator(aggregate_root_type: 'MyAggregate0', group_size:)
+          subject = event_store.event_streams_enumerator(aggregate_type: 'MyAggregate0', group_size:)
           aggregate_ids = subject.next
           expect(aggregate_ids).to eq(ordered_aggregate_ids[0...10])
           expect { subject.next }.to raise_error(StopIteration)
@@ -453,7 +453,7 @@ describe Sequent::Core::EventStore do
         end
 
         it 'finds all event streams of a specific type' do
-          subject = event_store.event_streams_enumerator(aggregate_root_type: 'MyAggregate1', group_size:)
+          subject = event_store.event_streams_enumerator(aggregate_type: 'MyAggregate1', group_size:)
           aggregate_ids = subject.next
           expect(aggregate_ids).to eq(ordered_aggregate_ids[10..])
           expect { subject.next }.to raise_error(StopIteration)

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -364,33 +364,101 @@ describe Sequent::Core::EventStore do
     end
   end
 
-  describe '#stream_exists?' do
-    before do
-      event_store.commit_events(
-        Sequent::Core::Command.new(aggregate_id: aggregate_id),
-        [
+  describe 'event_streams' do
+    context '#stream_exists?' do
+      before do
+        event_store.commit_events(
+          Sequent::Core::Command.new(aggregate_id: aggregate_id),
           [
-            Sequent::Core::EventStream.new(
-              aggregate_type: 'MyAggregate',
-              aggregate_id: aggregate_id,
-            ),
-            [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)],
+            [
+              Sequent::Core::EventStream.new(
+                aggregate_type: 'MyAggregate',
+                aggregate_id: aggregate_id,
+              ),
+              [MyEvent.new(aggregate_id: aggregate_id, sequence_number: 1)],
+            ],
           ],
-        ],
-      )
+        )
+      end
+
+      it 'gets true for an existing aggregate' do
+        expect(event_store.stream_exists?(aggregate_id)).to eq(true)
+      end
+
+      it 'gets false for an non-existing aggregate' do
+        expect(event_store.stream_exists?(Sequent.new_uuid)).to eq(false)
+      end
+
+      it 'gets false after deletion' do
+        event_store.permanently_delete_event_stream(aggregate_id)
+        expect(event_store.stream_exists?(aggregate_id)).to eq(false)
+      end
     end
 
-    it 'gets true for an existing aggregate' do
-      expect(event_store.stream_exists?(aggregate_id)).to eq(true)
-    end
+    context '#event_streams_enumerator' do
+      let(:event_streams) do
+        Array.new(20) do |i|
+          Sequent::Core::EventStream.new(
+            aggregate_type: "MyAggregate#{i / 10}",
+            aggregate_id: Sequent.new_uuid,
+            events_partition_key: (i / 5).to_s,
+          )
+        end
+      end
+      let(:ordered_aggregate_ids) do
+        event_streams
+          .sort_by { |s| [s.events_partition_key, s.aggregate_id] }
+          .map(&:aggregate_id)
+      end
 
-    it 'gets false for an non-existing aggregate' do
-      expect(event_store.stream_exists?(Sequent.new_uuid)).to eq(false)
-    end
+      let(:group_size) { 100 }
 
-    it 'gets false after deletion' do
-      event_store.permanently_delete_event_stream(aggregate_id)
-      expect(event_store.stream_exists?(aggregate_id)).to eq(false)
+      before do
+        event_store.commit_events(
+          Sequent::Core::Command.new(aggregate_id:),
+          event_streams.map do |s|
+            [s, [MyEvent.new(aggregate_id: s.aggregate_id, sequence_number: 1)]]
+          end,
+        )
+      end
+
+      context 'fewer aggregates than group size' do
+        let(:group_size) { 100 }
+
+        it 'finds all event streams at once' do
+          subject = event_store.event_streams_enumerator(group_size:)
+          aggregate_ids = subject.next
+          expect(aggregate_ids).to eq(ordered_aggregate_ids)
+          expect { subject.next }.to raise_error(StopIteration)
+        end
+
+        it 'finds all event streams of a specific type' do
+          subject = event_store.event_streams_enumerator(aggregate_root_type: 'MyAggregate0', group_size:)
+          aggregate_ids = subject.next
+          expect(aggregate_ids).to eq(ordered_aggregate_ids[0...10])
+          expect { subject.next }.to raise_error(StopIteration)
+        end
+      end
+
+      context 'more aggregates than group size' do
+        let(:group_size) { 15 }
+
+        it 'finds all event streams' do
+          subject = event_store.event_streams_enumerator(group_size:)
+          aggregate_ids = subject.next
+          expect(aggregate_ids).to eq(ordered_aggregate_ids[0...group_size])
+          aggregate_ids = subject.next
+          expect(aggregate_ids).to eq(ordered_aggregate_ids[group_size..])
+          expect { subject.next }.to raise_error(StopIteration)
+        end
+
+        it 'finds all event streams of a specific type' do
+          subject = event_store.event_streams_enumerator(aggregate_root_type: 'MyAggregate1', group_size:)
+          aggregate_ids = subject.next
+          expect(aggregate_ids).to eq(ordered_aggregate_ids[10..])
+          expect { subject.next }.to raise_error(StopIteration)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Adds a new rake task `sequent:migrate:unique_keys` to load and update all unique keys of an aggregate (optionally filtered by type). This is needed when adding or modifying `unique_key` constraints on an aggregate to ensure all unique keys are present in the `aggregate_unique_keys` table so that uniqueness can be enforced by the database.