### PR TITLE
Optimize `MessageRouter#matches_message?`

### DIFF
--- a/lib/sequent/core/helpers/message_router.rb
+++ b/lib/sequent/core/helpers/message_router.rb
@@ -24,11 +24,9 @@ module Sequent
 
           matchers.each do |matcher|
             if matcher.is_a?(MessageMatchers::InstanceOf)
-              @instanceof_routes[matcher.expected_class] ||= Set.new
-              @instanceof_routes[matcher.expected_class] << handler
+              (@instanceof_routes[matcher.expected_class] ||= Set.new) << handler
             else
-              @routes[matcher] ||= Set.new
-              @routes[matcher] << handler
+              (@routes[matcher] ||= Set.new) << handler
             end
           end
         end

--- a/lib/sequent/core/helpers/message_router.rb
+++ b/lib/sequent/core/helpers/message_router.rb
@@ -20,10 +20,14 @@ module Sequent
         # or a falsey value otherwise.
         #
         def register_matchers(*matchers, handler)
+          fail ArgumentError, 'handler is required' if handler.nil?
+
           matchers.each do |matcher|
             if matcher.is_a?(MessageMatchers::InstanceOf)
+              @instanceof_routes[matcher.expected_class] ||= Set.new
               @instanceof_routes[matcher.expected_class] << handler
             else
+              @routes[matcher] ||= Set.new
               @routes[matcher] << handler
             end
           end
@@ -34,7 +38,7 @@ module Sequent
         #
         def match_message(message)
           result = Set.new
-          result.merge(@instanceof_routes[message.class])
+          result.merge(@instanceof_routes[message.class]) if @instanceof_routes.include?(message.class)
           @routes.each do |matcher, handlers|
             result.merge(handlers) if matcher.matches_message?(message)
           end
@@ -45,15 +49,16 @@ module Sequent
         # Returns true when there is at least one handler for the given message, or false otherwise.
         #
         def matches_message?(message)
-          match_message(message).any?
+          @instanceof_routes.include?(message.class) ||
+            @routes.keys.any? { |matcher| matcher.matches_message?(message) }
         end
 
         ##
         # Removes all routes from the router.
         #
         def clear_routes
-          @instanceof_routes = Hash.new { |h, k| h[k] = Set.new }
-          @routes = Hash.new { |h, k| h[k] = Set.new }
+          @instanceof_routes = {}
+          @routes = {}
         end
       end
     end

--- a/spec/lib/sequent/core/helpers/message_router_spec.rb
+++ b/spec/lib/sequent/core/helpers/message_router_spec.rb
@@ -9,7 +9,12 @@ describe Sequent::Core::Helpers::MessageRouter do
   let(:other_handler) { double('other handler') }
 
   describe '#match_message' do
-    subject { message_router.match_message(message) }
+    subject do
+      handlers = message_router.match_message(message)
+      # `match_message` must be consistent with `matches_message?`
+      expect(handlers.present?).to eq(message_router.matches_message?(message))
+      handlers
+    end
 
     class MyMessage < Sequent::Event; end
 


### PR DESCRIPTION
Avoid building up an entire set of handlers just to check if there are any handlers, but directly query the underlying routes.