### PR TITLE
Allow you to run the migration to Sequent 8 even if you have not updated `aggregate_id` to be UUID yet.

### DIFF
--- a/db/sequent_8_migration.sql
+++ b/db/sequent_8_migration.sql
@@ -23,7 +23,10 @@ SET max_parallel_maintenance_workers = 8;
 
 BEGIN;
 
+-- If you are using AWS RDS, or other managed databases, it may not allow you to set `temp_tablespaces`,
+-- Consider running the line below separately on a session to check if it is allowed. Or commenting it.
 SET temp_tablespaces = 'pg_default';
+
 SET search_path TO sequent_schema;
 
 ALTER SEQUENCE command_records_id_seq OWNED BY NONE;

--- a/db/sequent_8_migration.sql
+++ b/db/sequent_8_migration.sql
@@ -51,11 +51,11 @@ SELECT DISTINCT command_type
 ANALYZE aggregate_types, event_types, command_types;
 
 INSERT INTO aggregates (aggregate_id, aggregate_type_id, snapshot_threshold, created_at)
-SELECT aggregate_id, (SELECT t.id FROM aggregate_types t WHERE aggregate_type = t.type), snapshot_threshold, created_at AT TIME ZONE 'Europe/Amsterdam'
+SELECT aggregate_id::uuid, (SELECT t.id FROM aggregate_types t WHERE aggregate_type = t.type), snapshot_threshold, created_at AT TIME ZONE 'Europe/Amsterdam'
   FROM stream_records;
 
 WITH e AS MATERIALIZED (
-  SELECT aggregate_id,
+  SELECT aggregate_id::uuid,
          sequence_number,
          command_record_id,
          t.id AS event_type_id,
@@ -94,7 +94,7 @@ SELECT id,
   FROM command;
 
 INSERT INTO aggregates_that_need_snapshots (aggregate_id, snapshot_sequence_number_high_water_mark, snapshot_outdated_at)
-SELECT aggregate_id, MAX(sequence_number), NOW()
+SELECT aggregate_id::uuid, MAX(sequence_number), NOW()
   FROM event_records
  WHERE event_type = 'Sequent::Core::SnapshotEvent'
  GROUP BY 1
@@ -115,6 +115,6 @@ ALTER TABLE stream_records RENAME TO old_stream_records;
 SELECT clock_timestamp() AS migration_completed_at,
        clock_timestamp() - :'migration_started_at'::timestamptz AS migration_duration \gset
 
-\echo Migration complated in :migration_duration (started at :migration_started_at, completed at :migration_completed_at)
+\echo Migration completed in :migration_duration (started at :migration_started_at, completed at :migration_completed_at)
 
 \echo execute ROLLBACK to abort, COMMIT to commit followed by VACUUM VERBOSE ANALYZE to ensure good performance


### PR DESCRIPTION
The columns on the tables expect a UUID, but if you have not updated your old tables to use UUID for `aggregate_id` you would hit errors. (`... is of type uuid but expression is of type character varying`).

AFAIK there is no penalty/problem in case you already are using the UUID, the casting would be a no-op.