### PR TITLE
Add read-only mode option during offline migration

### DIFF
--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -65,7 +65,8 @@ module Sequent
                   :primary_database_role,
                   :primary_database_key,
                   :time_precision,
-                  :enable_autoregistration
+                  :enable_autoregistration,
+                  :enable_offline_migration_read_only_mode
 
     attr_reader :migrations_class_name,
                 :versions_table_name
@@ -127,6 +128,7 @@ module Sequent
       self.time_precision = DEFAULT_TIME_PRECISION
 
       self.enable_autoregistration = false
+      self.enable_offline_migration_read_only_mode = false
     end
 
     def can_use_multiple_databases?

--- a/lib/sequent/migrations/functions.rb
+++ b/lib/sequent/migrations/functions.rb
@@ -30,6 +30,10 @@ module Sequent
         @record_class.table_name
       end
 
+      def record_class_name
+        @record_class.name
+      end
+
       def copy(with_version)
         self.class.create(record_class, with_version)
       end

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -214,6 +214,7 @@ module Sequent
         rollback_migration
         raise e
       end
+
       ##
       # Last part of a view schema migration
       #
@@ -237,7 +238,13 @@ module Sequent
         return if Sequent.new_version == current_version
 
         ensure_version_correct!
-        in_view_schema { Versions.start_offline!(Sequent.new_version) }
+        in_view_schema do
+          Versions.start_offline!(
+            Sequent.new_version,
+            target_projectors: plan.projectors.map(&:name),
+            target_records: plan.alter_tables.map(&:record_class_name),
+          )
+        end
         Sequent.logger.info("Start migrate_offline for version #{Sequent.new_version}")
 
         executor.set_table_names_to_new_version(plan)

--- a/spec/lib/sequent/core/projector_spec.rb
+++ b/spec/lib/sequent/core/projector_spec.rb
@@ -7,8 +7,106 @@ describe Sequent::Core::Projector do
     class TestProjector1 < Sequent::Core::Projector
       self.skip_autoregister = true
     end
+
     expect do
       Sequent.configuration.event_handlers << TestProjector1.new
     end.to raise_error(/A Projector must manage at least one table/)
+  end
+
+  context 'given enable_offline_migration_read_only_mode set to true' do
+    class Versions < Sequent::Migrations::Projectors
+      def self.version
+        1
+      end
+    end
+
+    class MigrationTestRecord; end
+
+    class MigrationTestEvent < Sequent::Core::Event; end
+
+    class MigrationTestProjector < Sequent::Core::Projector
+      manages_tables MigrationTestRecord
+
+      on MigrationTestEvent do
+      end
+    end
+
+    before do
+      Sequent.configuration.migrations_class_name = Versions.name
+      Sequent.configuration.enable_offline_migration_read_only_mode = true
+    end
+
+    subject(:handle_message) do
+      MigrationTestProjector.new.handle_message(
+        MigrationTestEvent.new(aggregate_id: Sequent.new_uuid, sequence_number: 1),
+      )
+    end
+
+    context 'and no migration' do
+      it 'succeeds' do
+        expect { subject }.to_not raise_error
+      end
+    end
+
+    context 'and a migration for projector' do
+      before do
+        Sequent::Migrations::Versions.create!(version: 2, status:, target_projectors: [MigrationTestProjector.name])
+      end
+
+      after do
+        Sequent::Migrations::Versions.delete_all
+      end
+
+      context 'online migration' do
+        context 'running' do
+          let(:status) { Sequent::Migrations::Versions::MIGRATE_ONLINE_RUNNING }
+          it 'succeeds' do
+            expect { subject }.to_not raise_error
+          end
+        end
+
+        context 'finished' do
+          let(:status) { Sequent::Migrations::Versions::MIGRATE_ONLINE_FINISHED }
+          it 'succeeds' do
+            expect { subject }.to_not raise_error
+          end
+        end
+      end
+
+      context 'offline migration' do
+        context 'running' do
+          let(:status) { Sequent::Migrations::Versions::MIGRATE_OFFLINE_RUNNING }
+          it 'raises ReadOnlyModeEnabled ' do
+            expect { subject }.to raise_error(Sequent::Core::Projector::ReadOnlyModeEnabled)
+          end
+        end
+
+        context 'finished' do
+          let(:status) { Sequent::Migrations::Versions::DONE }
+          it 'raises ReadOnlyModeEnabled' do
+            expect { subject }.to raise_error(Sequent::Core::Projector::ReadOnlyModeEnabled)
+          end
+        end
+      end
+    end
+
+    context 'and a migration for managed_table' do
+      before do
+        Sequent::Migrations::Versions.create!(version: 2, status:, target_records: [MigrationTestRecord.name])
+      end
+
+      after do
+        Sequent::Migrations::Versions.delete_all
+      end
+
+      context 'offline migration' do
+        context 'running' do
+          let(:status) { Sequent::Migrations::Versions::MIGRATE_OFFLINE_RUNNING }
+          it 'raises ReadOnlyModeEnabled ' do
+            expect { subject }.to raise_error(Sequent::Core::Projector::ReadOnlyModeEnabled)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds read-only mode and fails with a `ReadOnlyModeEnabled` error given a newer running/done offline migration.