### PR TITLE
Register migrating resources on migration table

### DIFF
--- a/lib/sequent/migrations/functions.rb
+++ b/lib/sequent/migrations/functions.rb
@@ -30,6 +30,10 @@ module Sequent
         @record_class.table_name
       end
 
+      def record_class_name
+        @record_class.name
+      end
+
       def copy(with_version)
         self.class.create(record_class, with_version)
       end

--- a/lib/sequent/migrations/versions.rb
+++ b/lib/sequent/migrations/versions.rb
@@ -10,7 +10,9 @@ module Sequent
 
       def self.migration_sql
         <<~SQL.chomp
-          CREATE TABLE IF NOT EXISTS #{table_name} (version integer NOT NULL, CONSTRAINT version_pk PRIMARY KEY(version));
+          CREATE TABLE IF NOT EXISTS #{table_name} (version integer NOT NULL, target_projectors text[] DEFAULT '{}'::text[], target_records text[] DEFAULT '{}'::text[], CONSTRAINT version_pk PRIMARY KEY(version));
+          ALTER TABLE #{table_name} ADD COLUMN IF NOT EXISTS target_projectors text[] DEFAULT '{}'::text[];
+          ALTER TABLE #{table_name} ADD COLUMN IF NOT EXISTS target_records text[] DEFAULT '{}'::text[];
           ALTER TABLE #{table_name} drop constraint if exists only_one_running;
           ALTER TABLE #{table_name} ADD COLUMN IF NOT EXISTS status INTEGER DEFAULT NULL CONSTRAINT only_one_running CHECK (status in (1,2,3));
           ALTER TABLE #{table_name} ADD COLUMN IF NOT EXISTS xmin_xact_id BIGINT;
@@ -24,6 +26,9 @@ module Sequent
             -> {
               where(status: [MIGRATE_ONLINE_RUNNING, MIGRATE_ONLINE_FINISHED, MIGRATE_OFFLINE_RUNNING])
             }
+      scope :later_versions, -> { where('version > ?', Sequent.new_version) }
+      scope :migrate_offline_running, -> { where(status: MIGRATE_OFFLINE_RUNNING) }
+      scope :migrate_offline_running_or_done, -> { migrate_offline_running.or(done) }
 
       def self.current_version
         done.latest_version || 0
@@ -55,7 +60,7 @@ module Sequent
         running.where(version: new_version).delete_all
       end
 
-      def self.start_offline!(new_version)
+      def self.start_offline!(new_version, target_projectors: [], target_records: [])
         current_migration = find_by(version: new_version)
         fail MigrationNotStarted if current_migration.blank?
 
@@ -64,7 +69,11 @@ module Sequent
           fail MigrationDone if current_migration.status.nil?
           fail ConcurrentMigration if current_migration.status != MIGRATE_ONLINE_FINISHED
 
-          current_migration.update(status: MIGRATE_OFFLINE_RUNNING)
+          current_migration.update(
+            status: MIGRATE_OFFLINE_RUNNING,
+            target_projectors:,
+            target_records:,
+          )
         end
       rescue ActiveRecord::LockWaitTimeout
         raise ConcurrentMigration

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -214,6 +214,7 @@ module Sequent
         rollback_migration
         raise e
       end
+
       ##
       # Last part of a view schema migration
       #
@@ -237,7 +238,13 @@ module Sequent
         return if Sequent.new_version == current_version
 
         ensure_version_correct!
-        in_view_schema { Versions.start_offline!(Sequent.new_version) }
+        in_view_schema do
+          Versions.start_offline!(
+            Sequent.new_version,
+            target_projectors: plan.projectors.map(&:name),
+            target_records: plan.alter_tables.map(&:record_class_name),
+          )
+        end
         Sequent.logger.info("Start migrate_offline for version #{Sequent.new_version}")
 
         executor.set_table_names_to_new_version(plan)

--- a/lib/sequent/migrations/view_schema.rb
+++ b/lib/sequent/migrations/view_schema.rb
@@ -241,8 +241,8 @@ module Sequent
         in_view_schema do
           Versions.start_offline!(
             Sequent.new_version,
-            target_projectors: plan.projectors.map(&:name),
-            target_records: plan.alter_tables.map(&:record_class_name),
+            target_projectors: plan.projectors.map(&:name).sort,
+            target_records: plan.alter_tables.map(&:record_class_name).sort,
           )
         end
         Sequent.logger.info("Start migrate_offline for version #{Sequent.new_version}")

--- a/spec/lib/sequent/migrations/view_schema_spec.rb
+++ b/spec/lib/sequent/migrations/view_schema_spec.rb
@@ -439,6 +439,14 @@ describe Sequent::Migrations::ViewSchema do
         expect(Sequent::Migrations::Versions.done.maximum(:version)).to eq new_version
       end
 
+      it 'sets the affected resources' do
+        migrator.migrate_offline
+
+        expect(Sequent::Migrations::Versions.done.latest.target_projectors)
+          .to eq([AccountProjector.name, MessageProjector.name])
+        expect(Sequent::Migrations::Versions.done.latest.target_records).to eq []
+      end
+
       it 'ensures the "normal" table_names are set' do
         migrator.migrate_offline
 


### PR DESCRIPTION
Register the resources affected in the migrations table. Also add some convenience scopes on versions.