### PR TITLE
Fix view schema migration containing STI projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Changelog 8.2.1
+
+- Bug: Fix resetting column information and table_name when using Single Table Inheritance.
+- Improvement: Fail fast when passing a non managed_table to the Persistor
+- Improvement: Log current event when replaying fails
+
 # Changelog 8.2.0
 
 - The sequent gem now uses ActiveRecord migrations to handle the

--- a/lib/sequent/migrations/executor.rb
+++ b/lib/sequent/migrations/executor.rb
@@ -17,8 +17,8 @@ module Sequent
           sql_file = "#{Sequent.configuration.migration_sql_files_directory}/#{table.table_name}.sql"
           statements = sql_file_to_statements(sql_file) { |raw_sql| raw_sql.gsub('%SUFFIX%', "_#{migration.version}") }
           statements.each(&method(:exec_sql))
-          table.table_name = "#{table.table_name}_#{migration.version}"
-          table.reset_column_information
+          new_table_name = "#{table.table_name}_#{migration.version}"
+          set_table_name(table, new_table_name)
         end
       end
 
@@ -41,14 +41,13 @@ module Sequent
       def execute_offline(plan, current_version)
         plan.replay_tables.each do |migration|
           table = migration.record_class
-          current_table_name = table.table_name.gsub("_#{migration.version}", '')
+          new_table_name = table.table_name.gsub("_#{migration.version}", '')
           # 2 Rename old table
-          exec_sql("ALTER TABLE IF EXISTS #{current_table_name} RENAME TO #{current_table_name}_#{current_version}")
+          exec_sql("ALTER TABLE IF EXISTS #{new_table_name} RENAME TO #{new_table_name}_#{current_version}")
           # 3 Rename new table
-          exec_sql("ALTER TABLE #{table.table_name} RENAME TO #{current_table_name}")
+          exec_sql("ALTER TABLE #{table.table_name} RENAME TO #{new_table_name}")
           # Use new table from now on
-          table.table_name = current_table_name
-          table.reset_column_information
+          set_table_name(table, new_table_name)
         end
 
         plan.alter_tables.each do |migration|
@@ -64,8 +63,8 @@ module Sequent
       def reset_table_names(plan)
         plan.replay_tables.each do |migration|
           table = migration.record_class
-          table.table_name = table.table_name.gsub("_#{migration.version}", '')
-          table.reset_column_information
+          new_table_name = table.table_name.gsub("_#{migration.version}", '')
+          set_table_name(table, new_table_name)
         end
       end
 
@@ -74,12 +73,22 @@ module Sequent
           table = migration.record_class
           next if table.table_name.end_with?("_#{migration.version}")
 
-          table.table_name = "#{table.table_name}_#{migration.version}"
-          table.reset_column_information
+          new_table_name = "#{table.table_name}_#{migration.version}"
+          set_table_name(table, new_table_name)
+
           unless table.table_exists?
             fail MigrationError,
                  "Table #{table.table_name} does not exist. Did you run ViewSchema.migrate_online first?"
           end
+        end
+      end
+
+      private
+
+      def set_table_name(table, table_name)
+        [table, *table.descendants].each do |klass|
+          klass.table_name = table_name
+          klass.reset_column_information
         end
       end
     end

--- a/spec/fixtures/db/1/classes.rb
+++ b/spec/fixtures/db/1/classes.rb
@@ -45,3 +45,22 @@ end
 class ItemProjector < Sequent::Projector
   manages_tables ItemRecord, LineItemRecord
 end
+
+class BaseFooRecord < Sequent::ApplicationRecord
+  self.table_name = 'foo_records'
+end
+class FooRecord < BaseFooRecord; end
+class SpecialFooRecord < BaseFooRecord; end
+
+class MessageWithAddedColumnCreated < Sequent::Core::Event; end
+class FooProjector < Sequent::Projector
+  manages_tables BaseFooRecord
+
+  on MessageCreated do |event|
+    create_record(BaseFooRecord, {aggregate_id: event.aggregate_id, type: FooRecord.name})
+  end
+
+  on MessageWithAddedColumnCreated do |event|
+    create_record(BaseFooRecord, {aggregate_id: event.aggregate_id, type: FooRecord.name, description: 'foo'})
+  end
+end

--- a/spec/fixtures/db/1/foo_records.sql
+++ b/spec/fixtures/db/1/foo_records.sql
@@ -1,0 +1,8 @@
+CREATE TABLE foo_records%SUFFIX% (
+    id serial NOT NULL,
+    aggregate_id uuid NOT NULL,
+    type character varying NOT NULL,
+    CONSTRAINT foo_records_pkey%SUFFIX% PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX unique_foo_id%SUFFIX% ON foo_records%SUFFIX% USING btree (aggregate_id);

--- a/spec/fixtures/db/2/foo_records.sql
+++ b/spec/fixtures/db/2/foo_records.sql
@@ -1,0 +1,9 @@
+CREATE TABLE foo_records%SUFFIX% (
+    id serial NOT NULL,
+    aggregate_id uuid NOT NULL,
+    type character varying NOT NULL,
+    description character varying,
+    CONSTRAINT foo_records_pkey%SUFFIX% PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX unique_foo_id%SUFFIX% ON foo_records%SUFFIX% USING btree (aggregate_id);


### PR DESCRIPTION
Ensure all classes in a STI tree have the correct table_name
and column_information during the migration process.
Although `table_name = 'new_table_name'` internally also resets
all column information we are not sure this also happens
in all supported AR version. So to be sure we call `reset_column_information`
anyway.
