### PR TITLE
Track event partition key changes for aggregates

### DIFF
--- a/db/migrate/20250501120000_sequent_track_partition_key_changes.rb
+++ b/db/migrate/20250501120000_sequent_track_partition_key_changes.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class SequentTrackPartitionKeyChanges < ActiveRecord::Migration[7.2]
+  def up
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      create_table :partition_key_changes, id: false do |t|
+        t.uuid :aggregate_id, null: false, primary_key: true
+        t.text :old_partition_key, null: false
+        t.text :new_partition_key, null: false
+        t.timestamptz :created_at, null: false, default: -> { 'now()' }
+        t.timestamptz :updated_at, null: false, default: -> { 'now()' }
+      end
+
+      add_foreign_key :partition_key_changes,
+                      :aggregates,
+                      name: :aggregate_fk,
+                      primary_key: :aggregate_id,
+                      on_delete: :cascade,
+                      on_update: :cascade
+
+      execute_sql_file 'store_aggregates', version: 2
+    end
+  end
+
+  def down
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute_sql_file 'store_aggregates', version: 1
+      drop_table :partition_key_changes
+    end
+  end
+
+  private
+
+  def execute_sql_file(filename, version:)
+    say "Applying '#{filename}' version #{version}", true
+    suppress_messages do
+      execute File.read(
+        File.join(
+          File.dirname(__FILE__),
+          format('sequent/%s_v%02d.sql', filename, version),
+        ),
+      )
+    end
+  end
+end

--- a/db/migrate/sequent/store_aggregates_v02.sql
+++ b/db/migrate/sequent/store_aggregates_v02.sql
@@ -1,0 +1,45 @@
+CREATE OR REPLACE PROCEDURE store_aggregates(_aggregates_with_events jsonb)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+DECLARE
+  _aggregate jsonb;
+  _events jsonb;
+  _aggregate_id aggregates.aggregate_id%TYPE;
+  _events_partition_key aggregates.events_partition_key%TYPE;
+  _current_partition_key aggregates.events_partition_key%TYPE;
+  _snapshot_outdated_at aggregates_that_need_snapshots.snapshot_outdated_at%TYPE;
+BEGIN
+  FOR _aggregate, _events IN SELECT row->0, row->1 FROM jsonb_array_elements(_aggregates_with_events) AS row LOOP
+    _aggregate_id = _aggregate->>'aggregate_id';
+
+    _events_partition_key = COALESCE(_aggregate->>'events_partition_key', '');
+    INSERT INTO aggregates (aggregate_id, created_at, aggregate_type_id, events_partition_key)
+    VALUES (
+      _aggregate_id,
+      (_events->0->>'created_at')::timestamptz,
+      (SELECT id FROM aggregate_types WHERE type = _aggregate->>'aggregate_type'),
+      _events_partition_key
+    ) ON CONFLICT (aggregate_id) DO NOTHING;
+
+    _current_partition_key = (SELECT events_partition_key FROM aggregates WHERE aggregate_id = _aggregate_id);
+    IF _current_partition_key <> _events_partition_key THEN
+      INSERT INTO partition_key_changes AS row (aggregate_id, old_partition_key, new_partition_key)
+      VALUES (_aggregate_id, _current_partition_key, _events_partition_key)
+          ON CONFLICT (aggregate_id)
+          DO UPDATE SET new_partition_key = EXCLUDED.new_partition_key,
+                        updated_at = NOW()
+                  WHERE row.new_partition_key IS DISTINCT FROM EXCLUDED.new_partition_key;
+    ELSE
+      DELETE FROM partition_key_changes WHERE aggregate_id = _aggregate_id;
+    END IF;
+
+    _snapshot_outdated_at = _aggregate->>'snapshot_outdated_at';
+    IF _snapshot_outdated_at IS NOT NULL THEN
+      INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_outdated_at)
+      VALUES (_aggregate_id, _snapshot_outdated_at)
+          ON CONFLICT (aggregate_id) DO UPDATE
+         SET snapshot_outdated_at = LEAST(row.snapshot_outdated_at, EXCLUDED.snapshot_outdated_at)
+       WHERE row.snapshot_outdated_at IS DISTINCT FROM EXCLUDED.snapshot_outdated_at;
+    END IF;
+  END LOOP;
+END;
+$$;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -391,26 +391,32 @@ DECLARE
   _events jsonb;
   _aggregate_id aggregates.aggregate_id%TYPE;
   _events_partition_key aggregates.events_partition_key%TYPE;
+  _current_partition_key aggregates.events_partition_key%TYPE;
   _snapshot_outdated_at aggregates_that_need_snapshots.snapshot_outdated_at%TYPE;
 BEGIN
   FOR _aggregate, _events IN SELECT row->0, row->1 FROM jsonb_array_elements(_aggregates_with_events) AS row LOOP
     _aggregate_id = _aggregate->>'aggregate_id';
 
-    _events_partition_key = COALESCE(
-      _aggregate->>'events_partition_key',
-      (SELECT events_partition_key FROM aggregates WHERE aggregate_id = _aggregate_id),
-      ''
-    );
-
+    _events_partition_key = COALESCE(_aggregate->>'events_partition_key', '');
     INSERT INTO aggregates (aggregate_id, created_at, aggregate_type_id, events_partition_key)
     VALUES (
       _aggregate_id,
       (_events->0->>'created_at')::timestamptz,
       (SELECT id FROM aggregate_types WHERE type = _aggregate->>'aggregate_type'),
       _events_partition_key
-    ) ON CONFLICT (aggregate_id)
-      DO UPDATE SET events_partition_key = EXCLUDED.events_partition_key
-              WHERE aggregates.events_partition_key IS DISTINCT FROM EXCLUDED.events_partition_key;
+    ) ON CONFLICT (aggregate_id) DO NOTHING;
+
+    _current_partition_key = (SELECT events_partition_key FROM aggregates WHERE aggregate_id = _aggregate_id);
+    IF _current_partition_key <> _events_partition_key THEN
+      INSERT INTO partition_key_changes AS row (aggregate_id, old_partition_key, new_partition_key)
+      VALUES (_aggregate_id, _current_partition_key, _events_partition_key)
+          ON CONFLICT (aggregate_id)
+          DO UPDATE SET new_partition_key = EXCLUDED.new_partition_key,
+                        updated_at = NOW()
+                  WHERE row.new_partition_key IS DISTINCT FROM EXCLUDED.new_partition_key;
+    ELSE
+      DELETE FROM partition_key_changes WHERE aggregate_id = _aggregate_id;
+    END IF;
 
     _snapshot_outdated_at = _aggregate->>'snapshot_outdated_at';
     IF _snapshot_outdated_at IS NOT NULL THEN
@@ -872,6 +878,19 @@ CREATE TABLE sequent_schema.events_default (
 
 
 --
+-- Name: partition_key_changes; Type: TABLE; Schema: sequent_schema; Owner: -
+--
+
+CREATE TABLE sequent_schema.partition_key_changes (
+    aggregate_id uuid NOT NULL,
+    old_partition_key text NOT NULL,
+    new_partition_key text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
 -- Name: saved_event_records; Type: TABLE; Schema: sequent_schema; Owner: -
 --
 
@@ -1091,6 +1110,14 @@ ALTER TABLE ONLY sequent_schema.events_default
 
 
 --
+-- Name: partition_key_changes partition_key_changes_pkey; Type: CONSTRAINT; Schema: sequent_schema; Owner: -
+--
+
+ALTER TABLE ONLY sequent_schema.partition_key_changes
+    ADD CONSTRAINT partition_key_changes_pkey PRIMARY KEY (aggregate_id);
+
+
+--
 -- Name: saved_event_records saved_event_records_pkey; Type: CONSTRAINT; Schema: sequent_schema; Owner: -
 --
 
@@ -1282,6 +1309,14 @@ CREATE TRIGGER save_events_on_update_trigger AFTER UPDATE ON sequent_schema.even
 
 
 --
+-- Name: partition_key_changes aggregate_fk; Type: FK CONSTRAINT; Schema: sequent_schema; Owner: -
+--
+
+ALTER TABLE ONLY sequent_schema.partition_key_changes
+    ADD CONSTRAINT aggregate_fk FOREIGN KEY (aggregate_id) REFERENCES sequent_schema.aggregates(aggregate_id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+
+--
 -- Name: aggregate_unique_keys aggregate_unique_keys_aggregate_id_fkey; Type: FK CONSTRAINT; Schema: sequent_schema; Owner: -
 --
 
@@ -1352,6 +1387,7 @@ ALTER TABLE ONLY sequent_schema.snapshot_records
 SET search_path TO public, view_schema, sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250501120000'),
 ('20250312105100'),
 ('20250101000001'),
 ('20250101000000');

--- a/lib/sequent/internal/internal.rb
+++ b/lib/sequent/internal/internal.rb
@@ -6,9 +6,4 @@ require_relative 'event_type'
 require_relative 'partitioned_aggregate'
 require_relative 'partitioned_command'
 require_relative 'partitioned_event'
-
-module Sequent
-  module Internal
-  end
-  private_constant :Internal
-end
+require_relative 'partition_key_change'

--- a/lib/sequent/internal/partition_key_change.rb
+++ b/lib/sequent/internal/partition_key_change.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'active_record'
+require_relative '../application_record'
+require_relative '../migrations/versions'
+
+module Sequent
+  module Internal
+    class PartitionKeyChange < Sequent::ApplicationRecord
+      self.primary_key = %i[aggregate_id]
+
+      belongs_to :partitioned_aggregate, primary_key: :aggregate_id, foreign_key: :aggregate_id
+
+      def self.update_aggregate_partition_keys(limit:)
+        limit.times do
+          ActiveRecord::Base.transaction do
+            if Sequent::Migrations::Versions.running.present?
+              fail 'cannot update partition keys while view schema migration is running'
+            end
+
+            change = PartitionKeyChange.first
+            return unless change
+
+            PartitionedAggregate
+              .where(aggregate_id: change.aggregate_id)
+              .where('events_partition_key <> ?', change.new_partition_key)
+              .update_all(events_partition_key: change.new_partition_key)
+
+            change.destroy!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sequent/internal/partition_key_change.rb
+++ b/lib/sequent/internal/partition_key_change.rb
@@ -15,7 +15,8 @@ module Sequent
         limit.times do
           ActiveRecord::Base.transaction do
             if Sequent::Migrations::Versions.running.present?
-              fail 'cannot update partition keys while view schema migration is running'
+              fail Sequent::Migrations::ConcurrentMigration,
+                   'cannot update partition keys while view schema migration is running'
             end
 
             change = PartitionKeyChange.first

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -277,7 +277,7 @@ module Sequent
             EOS
             task :init
 
-            task :connect, ['sequent:init', :init, :set_env_var] do
+            task connect: ['sequent:init', :init, :set_env_var] do
               ensure_sequent_env_set!
 
               db_config = Sequent::Support::Database.read_config(@env)
@@ -309,7 +309,7 @@ module Sequent
             EOS
             task :init
 
-            task :connect, ['sequent:init', :init, :set_env_var] do
+            task connect: ['sequent:init', :init, :set_env_var] do
               ensure_sequent_env_set!
 
               Sequent.configuration.command_handlers << Sequent::Core::AggregateSnapshotter.new

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -299,7 +299,11 @@ module Sequent
               count = Sequent::Internal::PartitionKeyChange.count
               Sequent.logger.info "Applying #{count} partition key changes (limited to #{limit})"
 
-              Sequent::Internal::PartitionKeyChange.update_aggregate_partition_keys(limit:)
+              begin
+                Sequent::Internal::PartitionKeyChange.update_aggregate_partition_keys(limit:)
+              rescue Sequent::Migrations::ConcurrentMigration
+                Sequent.logger.error 'View schema migration is active so not updating partition keys'
+              end
             end
           end
 

--- a/spec/lib/sequent/internal/partitioned_storage_spec.rb
+++ b/spec/lib/sequent/internal/partitioned_storage_spec.rb
@@ -6,7 +6,7 @@ module Sequent
   module Internal
     describe 'partitioned storage' do
       let(:aggregate_id) { Sequent.new_uuid }
-      let(:events_partition_key) { 'abc' }
+      let(:events_partition_key) { 'partition-key' }
 
       let(:event_store) { Sequent.configuration.event_store }
 
@@ -44,6 +44,54 @@ module Sequent
         expect(command).to be_present
         expect(command.command_type.type).to eq('Sequent::Core::Command')
         expect(command.partitioned_events).to eq(events)
+      end
+
+      context 'changed partition key' do
+        let(:updated_events_partition_key) { 'new-key' }
+
+        before do
+          PartitionKeyChange.delete_all
+
+          event_store.commit_events(
+            Sequent::Core::Command.new(aggregate_id:),
+            [
+              [
+                Sequent::Core::EventStream.new(
+                  aggregate_type: 'Aggregate',
+                  aggregate_id:,
+                  events_partition_key: updated_events_partition_key,
+                ),
+                [
+                  Sequent::Core::Event.new(aggregate_id:, sequence_number: 2),
+                ],
+              ],
+            ],
+          )
+        end
+
+        it 'logs the changed partition key' do
+          aggregate = PartitionedAggregate.first
+          expect(aggregate.events_partition_key).to eq(events_partition_key)
+
+          logged_change = PartitionKeyChange.find_by!(aggregate_id:)
+          expect(logged_change.partitioned_aggregate).to be_present
+          expect(logged_change.old_partition_key).to eq(aggregate.events_partition_key)
+          expect(logged_change.new_partition_key).to eq(updated_events_partition_key)
+        end
+
+        it 'updates the aggregate and events using a maintenance task' do
+          PartitionKeyChange.update_aggregate_partition_keys(limit: 10)
+
+          logged_change = PartitionKeyChange.find_by(aggregate_id:)
+          expect(logged_change).to be_nil
+
+          aggregate = PartitionedAggregate.find_by!(aggregate_id:)
+          expect(aggregate.events_partition_key).to eq(updated_events_partition_key)
+
+          events = aggregate.partitioned_events.to_a
+          expect(events.size).to eq(2)
+          expect(events).to all(have_attributes(partition_key: updated_events_partition_key))
+        end
       end
     end
   end


### PR DESCRIPTION
Before the partition key of an aggregate and its events where immediately updated. Unfortunately the view schema migration relies on a stable ordering of aggregates based on `events_partition_key, aggregate_id`. But if this changes while a migration is running the aggregate may not be replayed at all or be replayed multiple times.

With this change the partition key updates are only logged when an aggregate is updated and a separate maintenance task is used to perform the actual updates. This maintenance task can only be run when there is no view schema migration active.