### PR TITLE
Remove workarounds for activerecord 7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ A GitHub personal access token is required if you want Jekyll to retrieve GitHub
 Ensure the version in `lib/version.rb` is the new version. If not change it and update the sequent version for all the `gemfiles`:
 
 ```
-BUNDLE_GEMFILE=gemfiles/ar_7_1.gemfile bundle update sequent --conservative
 BUNDLE_GEMFILE=gemfiles/ar_7_2.gemfile bundle update sequent --conservative
 BUNDLE_GEMFILE=gemfiles/ar_8_0.gemfile bundle update sequent --conservative
 ```

--- a/gemfiles/ar_7_2.gemfile.lock
+++ b/gemfiles/ar_7_2.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     sequent (8.2.0)
-      activemodel (>= 7.1.3)
-      activerecord (>= 7.1.3)
+      activemodel (>= 7.2.1)
+      activerecord (>= 7.2.1)
       bcrypt (~> 3.1)
       csv (~> 3.3)
       gli (~> 2.22)

--- a/gemfiles/ar_8_0.gemfile.lock
+++ b/gemfiles/ar_8_0.gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ..
   specs:
     sequent (8.2.0)
-      activemodel (>= 7.1.3)
-      activerecord (>= 7.1.3)
+      activemodel (>= 7.2.1)
+      activerecord (>= 7.2.1)
       bcrypt (~> 3.1)
       csv (~> 3.3)
       gli (~> 2.22)

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -93,17 +93,10 @@ module Sequent
 
       belongs_to :parent_command, class_name: :CommandRecord, foreign_key: :command_record_id
 
-      if Gem.loaded_specs['activerecord'].version < Gem::Version.create('7.2')
-        has_many :child_commands,
-                 class_name: :CommandRecord,
-                 primary_key: %i[aggregate_id sequence_number],
-                 query_constraints: %i[event_aggregate_id event_sequence_number]
-      else
-        has_many :child_commands,
-                 class_name: :CommandRecord,
-                 primary_key: %i[aggregate_id sequence_number],
-                 foreign_key: %i[event_aggregate_id event_sequence_number]
-      end
+      has_many :child_commands,
+               class_name: :CommandRecord,
+               primary_key: %i[aggregate_id sequence_number],
+               query_constraints: %i[event_aggregate_id event_sequence_number]
 
       validates_presence_of :aggregate_id, :sequence_number, :event_type, :event_json, :stream_record, :parent_command
       validates_numericality_of :sequence_number, only_integer: true, greater_than: 0

--- a/lib/sequent/core/event_record.rb
+++ b/lib/sequent/core/event_record.rb
@@ -96,7 +96,7 @@ module Sequent
       has_many :child_commands,
                class_name: :CommandRecord,
                primary_key: %i[aggregate_id sequence_number],
-               query_constraints: %i[event_aggregate_id event_sequence_number]
+               foreign_key: %i[event_aggregate_id event_sequence_number]
 
       validates_presence_of :aggregate_id, :sequence_number, :event_type, :event_json, :stream_record, :parent_command
       validates_numericality_of :sequence_number, only_integer: true, greater_than: 0

--- a/lib/sequent/internal/partitioned_aggregate.rb
+++ b/lib/sequent/internal/partitioned_aggregate.rb
@@ -10,17 +10,10 @@ module Sequent
       self.primary_key = %i[aggregate_id]
 
       belongs_to :aggregate_type
-      if Gem.loaded_specs['activerecord'].version < Gem::Version.create('7.2')
-        has_many :partitioned_events,
-                 inverse_of: :partitioned_aggregate,
-                 primary_key: %w[events_partition_key aggregate_id],
-                 query_constraints: %w[partition_key aggregate_id]
-      else
-        has_many :partitioned_events,
-                 inverse_of: :partitioned_aggregate,
-                 primary_key: %i[events_partition_key aggregate_id],
-                 foreign_key: %i[partition_key aggregate_id]
-      end
+      has_many :partitioned_events,
+               inverse_of: :partitioned_aggregate,
+               primary_key: %i[events_partition_key aggregate_id],
+               foreign_key: %i[partition_key aggregate_id]
     end
   end
 end

--- a/lib/sequent/internal/partitioned_event.rb
+++ b/lib/sequent/internal/partitioned_event.rb
@@ -13,17 +13,10 @@ module Sequent
       belongs_to :partitioned_command,
                  inverse_of: :partitioned_events,
                  foreign_key: :command_id
-      if Gem.loaded_specs['activerecord'].version < Gem::Version.create('7.2')
-        belongs_to :partitioned_aggregate,
-                   inverse_of: :partitioned_events,
-                   primary_key: %w[partition_key aggregate_id],
-                   query_constraints: %w[events_partition_key aggregate_id]
-      else
-        belongs_to :partitioned_aggregate,
-                   inverse_of: :partitioned_events,
-                   primary_key: %w[partition_key aggregate_id],
-                   foreign_key: %w[events_partition_key aggregate_id]
-      end
+      belongs_to :partitioned_aggregate,
+                 inverse_of: :partitioned_events,
+                 primary_key: %w[partition_key aggregate_id],
+                 foreign_key: %w[events_partition_key aggregate_id]
     end
   end
 end

--- a/sequent.gemspec
+++ b/sequent.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
     'https://github.com/zilverline/sequent'
   s.license = 'MIT'
 
-  active_star_version = '>= 7.1.3'
+  active_star_version = '>= 7.2.1'
 
   rspec_version = '~> 3.10'
 

--- a/spec/lib/sequent/internal/partitioned_storage_spec.rb
+++ b/spec/lib/sequent/internal/partitioned_storage_spec.rb
@@ -25,18 +25,6 @@ module Sequent
       end
 
       it 'persists to the partitioned tables' do
-        if Gem.loaded_specs['activerecord'].version < Gem::Version.create('7.2')
-          skip("AR 7.1.3 doesn't allow correct configuration of composite foreign key constraint")
-          # AR 7.1.3 fails with `Association Sequent::Internal::PartitionedEvent#partitioned_aggregate primary key
-          # ["partition_key", "aggregate_id"] doesn't match with foreign key ["events_partition_key",
-          # "aggregate_id"]. Please specify query_constraints, or primary_key and foreign_key values.`, however
-          # specifying the `foreign_key` with multiple columns results in the error: `Passing ["events_partition_key",
-          # "aggregate_id"] array to :foreign_key option on the
-          # Sequent::Internal::PartitionedEvent#partitioned_aggregate association is not supported. Use the
-          # query_constraints: ["events_partition_key", "aggregate_id"] option instead to represent a composite foreign
-          # key.`
-        end
-
         aggregate = PartitionedAggregate.first
         expect(aggregate).to be_present
         expect(aggregate.aggregate_id).to eq(aggregate_id)


### PR DESCRIPTION
AR 7.1 is no longer supported by Sequent but some left-over workarounds were still present.