### PR TITLE
Aggregate snapshot versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Changelog 8.x
+
+- To prepare for rolling upgrades of Sequent based applications the
+  snapshot of an aggregate can now be versioned. This means that
+  whenever the snapshot format changes you should either delete all
+  snapshot on deployment of the new version (and ensure no old code is
+  running, which is a current requirement) or you should increment the
+  snapshot version using `enable_snapshots version: 2`. In this case the
+  old version of the code will continue to use snapshot version 1 (the
+  default version) while new code will only use snapshot version 2.
+
 # Changelog 8.2.1
 
 - Bug: Fix resetting column information and table_name when using Single Table Inheritance.

--- a/db/migrate/20250509133000_sequent_versioned_snapshots.rb
+++ b/db/migrate/20250509133000_sequent_versioned_snapshots.rb
@@ -53,7 +53,7 @@ class SequentVersionedSnapshots < ActiveRecord::Migration[7.2]
         SQL
       end
 
-      say 'Altering snapshot_records'
+      say 'Reverting snapshot_records'
       suppress_messages do
         execute <<~SQL
           ALTER TABLE snapshot_records

--- a/db/migrate/20250509133000_sequent_versioned_snapshots.rb
+++ b/db/migrate/20250509133000_sequent_versioned_snapshots.rb
@@ -30,8 +30,10 @@ class SequentVersionedSnapshots < ActiveRecord::Migration[7.2]
         SQL
       end
 
+      execute_sql_file 'aggregate_event_type', version: 2
       execute_sql_file 'aggregates_that_need_snapshots', version: 2
       execute_sql_file 'delete_snapshots_before', version: 2
+      execute_sql_file 'load_event', version: 2
       execute_sql_file 'load_events', version: 2
       execute_sql_file 'load_latest_snapshots', version: 2
       execute_sql_file 'select_aggregates_for_snapshotting', version: 2
@@ -66,8 +68,10 @@ class SequentVersionedSnapshots < ActiveRecord::Migration[7.2]
         SQL
       end
 
+      execute_sql_file 'aggregate_event_type', version: 1
       execute_sql_file 'aggregates_that_need_snapshots', version: 1
       execute_sql_file 'delete_snapshots_before', version: 1
+      execute_sql_file 'load_event', version: 1
       execute_sql_file 'load_events', version: 1
       execute_sql_file 'load_latest_snapshots', version: 1
       execute_sql_file 'select_aggregates_for_snapshotting', version: 1

--- a/db/migrate/20250509133000_sequent_versioned_snapshots.rb
+++ b/db/migrate/20250509133000_sequent_versioned_snapshots.rb
@@ -33,6 +33,7 @@ class SequentVersionedSnapshots < ActiveRecord::Migration[7.2]
       execute_sql_file 'aggregates_that_need_snapshots', version: 2
       execute_sql_file 'delete_snapshots_before', version: 2
       execute_sql_file 'load_events', version: 2
+      execute_sql_file 'load_latest_snapshots', version: 2
       execute_sql_file 'select_aggregates_for_snapshotting', version: 2
       execute_sql_file 'store_aggregates', version: 3
       execute_sql_file 'store_snapshots', version: 2
@@ -68,6 +69,7 @@ class SequentVersionedSnapshots < ActiveRecord::Migration[7.2]
       execute_sql_file 'aggregates_that_need_snapshots', version: 1
       execute_sql_file 'delete_snapshots_before', version: 1
       execute_sql_file 'load_events', version: 1
+      execute_sql_file 'load_latest_snapshots', version: 1
       execute_sql_file 'select_aggregates_for_snapshotting', version: 1
       execute_sql_file 'store_aggregates', version: 2
       execute_sql_file 'store_snapshots', version: 1

--- a/db/migrate/20250509133000_sequent_versioned_snapshots.rb
+++ b/db/migrate/20250509133000_sequent_versioned_snapshots.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class SequentVersionedSnapshots < ActiveRecord::Migration[7.2]
+  def up
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      say 'Altering aggregates_that_need_snapshots'
+      suppress_messages do
+        execute <<~SQL
+          ALTER TABLE aggregates_that_need_snapshots ADD COLUMN snapshot_version integer;
+          UPDATE aggregates_that_need_snapshots SET snapshot_version = 1;
+          ALTER TABLE aggregates_that_need_snapshots
+            ALTER COLUMN snapshot_version SET NOT NULL,
+            DROP CONSTRAINT aggregates_that_need_snapshots_pkey CASCADE,
+            ADD PRIMARY KEY (aggregate_id, snapshot_version);
+        SQL
+      end
+
+      say 'Altering snapshot_records'
+      suppress_messages do
+        execute <<~SQL
+          ALTER TABLE snapshot_records ADD COLUMN snapshot_version integer;
+          UPDATE snapshot_records SET snapshot_version = 1;
+          ALTER TABLE snapshot_records
+            ALTER COLUMN snapshot_version SET NOT NULL,
+            DROP CONSTRAINT snapshot_records_pkey CASCADE,
+            ADD PRIMARY KEY (aggregate_id, snapshot_version, sequence_number),
+            ADD FOREIGN KEY (aggregate_id, snapshot_version)
+                 REFERENCES aggregates_that_need_snapshots (aggregate_id, snapshot_version)
+                         ON DELETE CASCADE ON UPDATE CASCADE;
+        SQL
+      end
+
+      execute_sql_file 'aggregates_that_need_snapshots', version: 2
+      execute_sql_file 'delete_snapshots_before', version: 2
+      execute_sql_file 'load_events', version: 2
+      execute_sql_file 'select_aggregates_for_snapshotting', version: 2
+      execute_sql_file 'store_aggregates', version: 3
+      execute_sql_file 'store_snapshots', version: 2
+    end
+  end
+
+  def down
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      say 'Reverting aggregates_that_need_snapshots'
+      suppress_messages do
+        execute <<~SQL
+          DELETE FROM aggregates_that_need_snapshots WHERE snapshot_version <> 1;
+          ALTER TABLE aggregates_that_need_snapshots
+            DROP CONSTRAINT aggregates_that_need_snapshots_pkey CASCADE,
+            DROP COLUMN snapshot_version,
+            ADD PRIMARY KEY (aggregate_id);
+        SQL
+      end
+
+      say 'Altering snapshot_records'
+      suppress_messages do
+        execute <<~SQL
+          ALTER TABLE snapshot_records
+            DROP CONSTRAINT snapshot_records_pkey CASCADE,
+            DROP COLUMN snapshot_version,
+            ADD PRIMARY KEY (aggregate_id, sequence_number),
+            ADD FOREIGN KEY (aggregate_id)
+                 REFERENCES aggregates_that_need_snapshots (aggregate_id)
+                         ON DELETE CASCADE ON UPDATE CASCADE;
+        SQL
+      end
+
+      execute_sql_file 'aggregates_that_need_snapshots', version: 1
+      execute_sql_file 'delete_snapshots_before', version: 1
+      execute_sql_file 'load_events', version: 1
+      execute_sql_file 'select_aggregates_for_snapshotting', version: 1
+      execute_sql_file 'store_aggregates', version: 2
+      execute_sql_file 'store_snapshots', version: 1
+    end
+  end
+
+  private
+
+  def execute_sql_file(filename, version:)
+    say "Applying '#{filename}' version #{version}", true
+    suppress_messages do
+      execute File.read(
+        File.join(
+          File.dirname(__FILE__),
+          format('sequent/%s_v%02d.sql', filename, version),
+        ),
+      )
+    end
+  end
+end

--- a/db/migrate/sequent/aggregate_event_type_v02.sql
+++ b/db/migrate/sequent/aggregate_event_type_v02.sql
@@ -3,6 +3,7 @@ CREATE TYPE aggregate_event_type AS (
   aggregate_type text,
   aggregate_id uuid,
   events_partition_key text,
+  event_sequence_number integer,
   event_type text,
   event_json jsonb
 );

--- a/db/migrate/sequent/aggregates_that_need_snapshots_v01.sql
+++ b/db/migrate/sequent/aggregates_that_need_snapshots_v01.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS aggregates_that_need_snapshots(_last_aggregate_id uuid, _limit integer, _snapshot_version_by_type jsonb);
+
 CREATE OR REPLACE FUNCTION aggregates_that_need_snapshots(_last_aggregate_id uuid, _limit integer)
   RETURNS TABLE (aggregate_id uuid)
 LANGUAGE plpgsql SET search_path FROM CURRENT AS $$

--- a/db/migrate/sequent/aggregates_that_need_snapshots_v02.sql
+++ b/db/migrate/sequent/aggregates_that_need_snapshots_v02.sql
@@ -9,7 +9,7 @@ BEGIN
     JOIN aggregates a ON s.aggregate_id = a.aggregate_id
     JOIN aggregate_types type ON a.aggregate_type_id = type.id
    WHERE s.snapshot_outdated_at IS NOT NULL
-     AND s.snapshot_version = COALESCE((_snapshot_version_by_type->(type.type))::integer, 1)
+     AND s.snapshot_version = COALESCE((_snapshot_version_by_type->>(type.type))::integer, 1)
      AND (_last_aggregate_id IS NULL OR s.aggregate_id > _last_aggregate_id)
    ORDER BY 1
    LIMIT _limit;

--- a/db/migrate/sequent/aggregates_that_need_snapshots_v02.sql
+++ b/db/migrate/sequent/aggregates_that_need_snapshots_v02.sql
@@ -1,0 +1,17 @@
+DROP FUNCTION IF EXISTS aggregates_that_need_snapshots(_last_aggregate_id uuid, _limit integer);
+
+CREATE OR REPLACE FUNCTION aggregates_that_need_snapshots(_last_aggregate_id uuid, _limit integer, _snapshot_version_by_type jsonb DEFAULT '{}')
+  RETURNS TABLE (aggregate_id uuid)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+BEGIN
+  RETURN QUERY SELECT a.aggregate_id
+    FROM aggregates_that_need_snapshots s
+    JOIN aggregates a ON s.aggregate_id = a.aggregate_id
+    JOIN aggregate_types type ON a.aggregate_type_id = type.id
+   WHERE s.snapshot_outdated_at IS NOT NULL
+     AND s.snapshot_version = COALESCE((_snapshot_version_by_type->(type.type))::integer, 1)
+     AND (_last_aggregate_id IS NULL OR s.aggregate_id > _last_aggregate_id)
+   ORDER BY 1
+   LIMIT _limit;
+END;
+$$;

--- a/db/migrate/sequent/delete_snapshots_before_v01.sql
+++ b/db/migrate/sequent/delete_snapshots_before_v01.sql
@@ -1,3 +1,10 @@
+DROP PROCEDURE IF EXISTS delete_snapshots_before(
+  _aggregate_id uuid,
+  _sequence_number integer,
+  _now timestamp with time zone,
+  _snapshot_version_by_type jsonb
+);
+
 CREATE OR REPLACE PROCEDURE delete_snapshots_before(_aggregate_id uuid, _sequence_number integer, _now timestamp with time zone DEFAULT NOW())
 LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
 BEGIN

--- a/db/migrate/sequent/delete_snapshots_before_v02.sql
+++ b/db/migrate/sequent/delete_snapshots_before_v02.sql
@@ -11,7 +11,7 @@ BEGIN
   DELETE FROM snapshot_records s
    WHERE aggregate_id = _aggregate_id
      AND snapshot_version = COALESCE(
-           (SELECT _snapshot_version_by_type->(type.type)
+           (SELECT _snapshot_version_by_type->>(type.type)
               FROM aggregates
               JOIN aggregate_types type ON aggregate_type_id = type.id
              WHERE s.aggregate_id = aggregates.aggregate_id)::integer,

--- a/db/migrate/sequent/delete_snapshots_before_v02.sql
+++ b/db/migrate/sequent/delete_snapshots_before_v02.sql
@@ -1,0 +1,28 @@
+DROP PROCEDURE IF EXISTS delete_snapshots_before(_aggregate_id uuid, _sequence_number integer, _now timestamp with time zone);
+
+CREATE OR REPLACE PROCEDURE delete_snapshots_before(
+  _aggregate_id uuid,
+  _sequence_number integer,
+  _now timestamp with time zone DEFAULT NOW(),
+  _snapshot_version_by_type jsonb DEFAULT '{}'
+)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+BEGIN
+  DELETE FROM snapshot_records s
+   WHERE aggregate_id = _aggregate_id
+     AND snapshot_version = COALESCE(
+           (SELECT _snapshot_version_by_type->(type.type)
+              FROM aggregates
+              JOIN aggregate_types type ON aggregate_type_id = type.id
+             WHERE s.aggregate_id = aggregates.aggregate_id)::integer,
+           1
+         )
+     AND sequence_number < _sequence_number;
+
+  UPDATE aggregates_that_need_snapshots a
+     SET snapshot_outdated_at = _now
+   WHERE aggregate_id = _aggregate_id
+     AND snapshot_outdated_at IS NULL
+     AND NOT EXISTS (SELECT 1 FROM snapshot_records s WHERE aggregate_id = _aggregate_id AND a.snapshot_version = s.snapshot_version);
+END;
+$$;

--- a/db/migrate/sequent/load_event_v02.sql
+++ b/db/migrate/sequent/load_event_v02.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION load_event(
+  _aggregate_id uuid,
+  _sequence_number integer
+) RETURNS SETOF aggregate_event_type RETURNS NULL ON NULL INPUT
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+BEGIN
+  RETURN QUERY SELECT aggregate_types.type,
+         a.aggregate_id,
+         a.events_partition_key,
+         e.sequence_number,
+         event_types.type,
+         enrich_event_json(e)
+    FROM aggregates a
+        INNER JOIN events e ON (a.events_partition_key, a.aggregate_id) = (e.partition_key, e.aggregate_id)
+        INNER JOIN aggregate_types ON a.aggregate_type_id = aggregate_types.id
+        INNER JOIN event_types ON e.event_type_id = event_types.id
+   WHERE a.aggregate_id = _aggregate_id
+     AND e.sequence_number = _sequence_number;
+END;
+$$;

--- a/db/migrate/sequent/load_events_v02.sql
+++ b/db/migrate/sequent/load_events_v02.sql
@@ -22,19 +22,13 @@ BEGIN
          WHERE aggregate_id = _aggregate_id
       ),
       snapshot AS MATERIALIZED (
-        SELECT *
-          FROM snapshot_records
+        SELECT s.*
+          FROM snapshot_records s JOIN aggregate ON s.aggregate_id = aggregate.aggregate_id
          WHERE _use_snapshots
-           AND aggregate_id = _aggregate_id
+           AND s.aggregate_id = _aggregate_id
            AND (_until IS NULL OR created_at < _until)
-           AND snapshot_version = COALESCE(
-                 (SELECT snapshot_version_by_type.value
-                    FROM jsonb_each(_snapshot_version_by_type) AS snapshot_version_by_type(type, value)
-                    JOIN aggregate ON snapshot_records.aggregate_id = aggregate.aggregate_id
-                   WHERE aggregate.type = snapshot_version_by_type.type)::integer,
-                 1
-               )
-         ORDER BY sequence_number DESC LIMIT 1
+           AND snapshot_version = COALESCE((_snapshot_version_by_type->(aggregate.type))::integer, 1)
+         ORDER BY s.sequence_number DESC LIMIT 1
       )
     (SELECT a.*, s.snapshot_type, s.snapshot_json FROM aggregate a, snapshot s)
     UNION ALL

--- a/db/migrate/sequent/load_latest_snapshots_v01.sql
+++ b/db/migrate/sequent/load_latest_snapshots_v01.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS load_latest_snapshot(_aggregate_id uuid, _snapshot_version_by_type jsonb);
+
 CREATE OR REPLACE FUNCTION load_latest_snapshot(_aggregate_id uuid) RETURNS aggregate_event_type
 LANGUAGE SQL SET search_path FROM CURRENT AS $$
   SELECT (SELECT type FROM aggregate_types WHERE id = a.aggregate_type_id),

--- a/db/migrate/sequent/load_latest_snapshots_v02.sql
+++ b/db/migrate/sequent/load_latest_snapshots_v02.sql
@@ -1,0 +1,18 @@
+DROP FUNCTION IF EXISTS load_latest_snapshot(_aggregate_id uuid);
+
+CREATE OR REPLACE FUNCTION load_latest_snapshot(_aggregate_id uuid, _snapshot_version_by_type jsonb DEFAULT '{}')
+RETURNS aggregate_event_type
+LANGUAGE SQL SET search_path FROM CURRENT AS $$
+  SELECT t.type,
+         a.aggregate_id,
+         a.events_partition_key,
+         s.snapshot_type,
+         s.snapshot_json
+    FROM aggregates a
+    JOIN aggregate_types t on a.aggregate_type_id = t.id
+    JOIN snapshot_records s ON a.aggregate_id = s.aggregate_id
+   WHERE a.aggregate_id = _aggregate_id
+     AND s.snapshot_version = COALESCE((_snapshot_version_by_type->>(t.type))::integer, 1)
+   ORDER BY s.sequence_number DESC
+   LIMIT 1;
+$$;

--- a/db/migrate/sequent/load_latest_snapshots_v02.sql
+++ b/db/migrate/sequent/load_latest_snapshots_v02.sql
@@ -6,6 +6,7 @@ LANGUAGE SQL SET search_path FROM CURRENT AS $$
   SELECT t.type,
          a.aggregate_id,
          a.events_partition_key,
+         0 AS sequence_number,
          s.snapshot_type,
          s.snapshot_json
     FROM aggregates a

--- a/db/migrate/sequent/select_aggregates_for_snapshotting_v02.sql
+++ b/db/migrate/sequent/select_aggregates_for_snapshotting_v02.sql
@@ -6,7 +6,7 @@ CREATE OR REPLACE FUNCTION select_aggregates_for_snapshotting(
   _now timestamp with time zone DEFAULT NOW(),
   _snapshot_version_by_type jsonb DEFAULT '{}'
 )
-  RETURNS TABLE (aggregate_id uuid)
+  RETURNS SETOF aggregates_that_need_snapshots
 LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
 BEGIN
   RETURN QUERY WITH scheduled AS MATERIALIZED (
@@ -32,7 +32,7 @@ BEGIN
         AND (row.snapshot_scheduled_at IS NULL OR row.snapshot_scheduled_at < _reschedule_snapshot_scheduled_before)
      RETURNING row.*
    )
-   SELECT updated.aggregate_id
+   SELECT *
      FROM updated
     ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC;
 END;

--- a/db/migrate/sequent/select_aggregates_for_snapshotting_v02.sql
+++ b/db/migrate/sequent/select_aggregates_for_snapshotting_v02.sql
@@ -23,12 +23,17 @@ BEGIN
      ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC
      LIMIT _limit
        FOR UPDATE
-   ) UPDATE aggregates_that_need_snapshots AS row
+   ), updated AS MATERIALIZED (
+     UPDATE aggregates_that_need_snapshots AS row
         SET snapshot_scheduled_at = _now
        FROM scheduled
       WHERE row.aggregate_id = scheduled.aggregate_id
         AND row.snapshot_version = scheduled.snapshot_version
         AND (row.snapshot_scheduled_at IS NULL OR row.snapshot_scheduled_at < _reschedule_snapshot_scheduled_before)
-    RETURNING row.aggregate_id;
+     RETURNING row.*
+   )
+   SELECT updated.aggregate_id
+     FROM updated
+    ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC;
 END;
 $$;

--- a/db/migrate/sequent/select_aggregates_for_snapshotting_v02.sql
+++ b/db/migrate/sequent/select_aggregates_for_snapshotting_v02.sql
@@ -1,18 +1,25 @@
-DROP FUNCTION IF EXISTS select_aggregates_for_snapshotting(
+DROP FUNCTION IF EXISTS select_aggregates_for_snapshotting(_limit integer, _reschedule_snapshot_scheduled_before timestamp with time zone, _now timestamp with time zone);
+
+CREATE OR REPLACE FUNCTION select_aggregates_for_snapshotting(
   _limit integer,
   _reschedule_snapshot_scheduled_before timestamp with time zone,
-  _now timestamp with time zone,
-  _snapshot_version_by_type jsonb
-);
-
-CREATE OR REPLACE FUNCTION select_aggregates_for_snapshotting(_limit integer, _reschedule_snapshot_scheduled_before timestamp with time zone, _now timestamp with time zone DEFAULT NOW())
+  _now timestamp with time zone DEFAULT NOW(),
+  _snapshot_version_by_type jsonb DEFAULT '{}'
+)
   RETURNS TABLE (aggregate_id uuid)
 LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
 BEGIN
   RETURN QUERY WITH scheduled AS MATERIALIZED (
-    SELECT a.aggregate_id
-      FROM aggregates_that_need_snapshots AS a
+    SELECT s.aggregate_id
+      FROM aggregates_that_need_snapshots AS s
      WHERE snapshot_outdated_at IS NOT NULL
+       AND snapshot_version = COALESCE(
+             (SELECT _snapshot_version_by_type->(type.type)
+                FROM aggregates
+                JOIN aggregate_types type ON aggregate_type_id = type.id
+               WHERE s.aggregate_id = aggregates.aggregate_id)::integer,
+             1
+           )
      ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC
      LIMIT _limit
        FOR UPDATE

--- a/db/migrate/sequent/store_aggregates_v03.sql
+++ b/db/migrate/sequent/store_aggregates_v03.sql
@@ -34,9 +34,9 @@ BEGIN
 
     _snapshot_outdated_at = _aggregate->>'snapshot_outdated_at';
     IF _snapshot_outdated_at IS NOT NULL THEN
-      INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_outdated_at)
-      VALUES (_aggregate_id, _snapshot_outdated_at)
-          ON CONFLICT (aggregate_id) DO UPDATE
+      INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_version, snapshot_outdated_at)
+      VALUES (_aggregate_id, COALESCE((_aggregate->>'snapshot_version')::integer, 1), _snapshot_outdated_at)
+          ON CONFLICT (aggregate_id, snapshot_version) DO UPDATE
          SET snapshot_outdated_at = LEAST(row.snapshot_outdated_at, EXCLUDED.snapshot_outdated_at)
        WHERE row.snapshot_outdated_at IS DISTINCT FROM EXCLUDED.snapshot_outdated_at;
     END IF;

--- a/db/migrate/sequent/store_snapshots_v02.sql
+++ b/db/migrate/sequent/store_snapshots_v02.sql
@@ -1,0 +1,33 @@
+CREATE OR REPLACE PROCEDURE store_snapshots(_snapshots jsonb)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+DECLARE
+  _aggregate_id uuid;
+  _snapshot jsonb;
+  _snapshot_version integer;
+  _sequence_number snapshot_records.sequence_number%TYPE;
+BEGIN
+  FOR _snapshot IN SELECT * FROM jsonb_array_elements(_snapshots) LOOP
+    _aggregate_id = _snapshot->>'aggregate_id';
+    _sequence_number = _snapshot->'sequence_number';
+    _snapshot_version = _snapshot->'snapshot_version';
+
+    INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_version, snapshot_sequence_number_high_water_mark)
+    VALUES (_aggregate_id, _snapshot_version, _sequence_number)
+        ON CONFLICT (aggregate_id, snapshot_version) DO UPDATE
+       SET snapshot_sequence_number_high_water_mark =
+             GREATEST(row.snapshot_sequence_number_high_water_mark, EXCLUDED.snapshot_sequence_number_high_water_mark),
+           snapshot_outdated_at = NULL,
+           snapshot_scheduled_at = NULL;
+
+    INSERT INTO snapshot_records (aggregate_id, snapshot_version, sequence_number, created_at, snapshot_type, snapshot_json)
+    VALUES (
+      _aggregate_id,
+      _snapshot_version,
+      _sequence_number,
+      (_snapshot->>'created_at')::timestamptz,
+      _snapshot->>'snapshot_type',
+      _snapshot->'snapshot_json'
+    );
+  END LOOP;
+END;
+$$;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1505,3 +1505,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20250312105100'),
 ('20250101000001'),
 ('20250101000000');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -250,20 +250,23 @@ $$;
 
 
 --
--- Name: load_latest_snapshot(uuid); Type: FUNCTION; Schema: sequent_schema; Owner: -
+-- Name: load_latest_snapshot(uuid, jsonb); Type: FUNCTION; Schema: sequent_schema; Owner: -
 --
 
-CREATE FUNCTION sequent_schema.load_latest_snapshot(_aggregate_id uuid) RETURNS sequent_schema.aggregate_event_type
+CREATE FUNCTION sequent_schema.load_latest_snapshot(_aggregate_id uuid, _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb) RETURNS sequent_schema.aggregate_event_type
     LANGUAGE sql
     SET search_path TO 'sequent_schema'
     AS $$
-  SELECT (SELECT type FROM aggregate_types WHERE id = a.aggregate_type_id),
+  SELECT t.type,
          a.aggregate_id,
          a.events_partition_key,
          s.snapshot_type,
          s.snapshot_json
-    FROM aggregates a JOIN snapshot_records s ON a.aggregate_id = s.aggregate_id
+    FROM aggregates a
+    JOIN aggregate_types t on a.aggregate_type_id = t.id
+    JOIN snapshot_records s ON a.aggregate_id = s.aggregate_id
    WHERE a.aggregate_id = _aggregate_id
+     AND s.snapshot_version = COALESCE((_snapshot_version_by_type->(t.type))::integer, 1)
    ORDER BY s.sequence_number DESC
    LIMIT 1;
 $$;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -414,72 +414,25 @@ END;
 $$;
 
 
-SET default_table_access_method = heap;
-
---
--- Name: aggregates_that_need_snapshots; Type: TABLE; Schema: sequent_schema; Owner: -
---
-
-CREATE TABLE sequent_schema.aggregates_that_need_snapshots (
-    aggregate_id uuid NOT NULL,
-    snapshot_sequence_number_high_water_mark integer,
-    snapshot_outdated_at timestamp with time zone,
-    snapshot_scheduled_at timestamp with time zone,
-    snapshot_version integer NOT NULL
-);
-
-
---
--- Name: TABLE aggregates_that_need_snapshots; Type: COMMENT; Schema: sequent_schema; Owner: -
---
-
-COMMENT ON TABLE sequent_schema.aggregates_that_need_snapshots IS 'Contains a row for every aggregate with more events than its snapshot threshold.';
-
-
---
--- Name: COLUMN aggregates_that_need_snapshots.snapshot_sequence_number_high_water_mark; Type: COMMENT; Schema: sequent_schema; Owner: -
---
-
-COMMENT ON COLUMN sequent_schema.aggregates_that_need_snapshots.snapshot_sequence_number_high_water_mark IS 'The highest sequence number of the stored snapshot. Kept when snapshot are deleted to more easily query aggregates that need snapshotting the most';
-
-
---
--- Name: COLUMN aggregates_that_need_snapshots.snapshot_outdated_at; Type: COMMENT; Schema: sequent_schema; Owner: -
---
-
-COMMENT ON COLUMN sequent_schema.aggregates_that_need_snapshots.snapshot_outdated_at IS 'Not NULL indicates a snapshot is needed since the stored timestamp';
-
-
---
--- Name: COLUMN aggregates_that_need_snapshots.snapshot_scheduled_at; Type: COMMENT; Schema: sequent_schema; Owner: -
---
-
-COMMENT ON COLUMN sequent_schema.aggregates_that_need_snapshots.snapshot_scheduled_at IS 'Not NULL indicates a snapshot is in the process of being taken';
-
-
 --
 -- Name: select_aggregates_for_snapshotting(integer, timestamp with time zone, timestamp with time zone, jsonb); Type: FUNCTION; Schema: sequent_schema; Owner: -
 --
 
-CREATE FUNCTION sequent_schema.select_aggregates_for_snapshotting(_limit integer, _reschedule_snapshot_scheduled_before timestamp with time zone, _now timestamp with time zone DEFAULT now(), _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb) RETURNS SETOF sequent_schema.aggregates_that_need_snapshots
+CREATE FUNCTION sequent_schema.select_aggregates_for_snapshotting(_limit integer, _reschedule_snapshot_scheduled_before timestamp with time zone, _now timestamp with time zone DEFAULT now(), _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb) RETURNS TABLE(aggregate_id uuid, aggregate_type text, snapshot_version integer)
     LANGUAGE plpgsql
     SET search_path TO 'sequent_schema'
     AS $$
 BEGIN
   RETURN QUERY WITH scheduled AS MATERIALIZED (
-    SELECT s.aggregate_id, s.snapshot_version
+    SELECT s.*, t.type AS aggregate_type
       FROM aggregates_that_need_snapshots AS s
-     WHERE snapshot_outdated_at IS NOT NULL
-       AND snapshot_version = COALESCE(
-             (SELECT _snapshot_version_by_type->>(type.type)
-                FROM aggregates
-                JOIN aggregate_types type ON aggregate_type_id = type.id
-               WHERE s.aggregate_id = aggregates.aggregate_id)::integer,
-             1
-           )
-     ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC
+      JOIN aggregates a ON s.aggregate_id = a.aggregate_id
+      JOIN aggregate_types t ON a.aggregate_type_id = t.id
+     WHERE s.snapshot_outdated_at IS NOT NULL
+       AND s.snapshot_version = COALESCE((_snapshot_version_by_type->>(t.type))::integer, 1)
+     ORDER BY s.snapshot_outdated_at ASC, s.snapshot_sequence_number_high_water_mark DESC, s.aggregate_id ASC
      LIMIT _limit
-       FOR UPDATE
+       FOR UPDATE OF s SKIP LOCKED
    ), updated AS MATERIALIZED (
      UPDATE aggregates_that_need_snapshots AS row
         SET snapshot_scheduled_at = _now
@@ -487,9 +440,9 @@ BEGIN
       WHERE row.aggregate_id = scheduled.aggregate_id
         AND row.snapshot_version = scheduled.snapshot_version
         AND (row.snapshot_scheduled_at IS NULL OR row.snapshot_scheduled_at < _reschedule_snapshot_scheduled_before)
-     RETURNING row.*
+     RETURNING scheduled.*
    )
-   SELECT *
+   SELECT updated.aggregate_id, updated.aggregate_type, updated.snapshot_version
      FROM updated
     ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC;
 END;
@@ -773,6 +726,8 @@ END;
 $$;
 
 
+SET default_table_access_method = heap;
+
 --
 -- Name: ar_internal_metadata; Type: TABLE; Schema: public; Owner: -
 --
@@ -852,6 +807,47 @@ CREATE TABLE sequent_schema.aggregates_default (
     aggregate_type_id smallint NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+
+--
+-- Name: aggregates_that_need_snapshots; Type: TABLE; Schema: sequent_schema; Owner: -
+--
+
+CREATE TABLE sequent_schema.aggregates_that_need_snapshots (
+    aggregate_id uuid NOT NULL,
+    snapshot_sequence_number_high_water_mark integer,
+    snapshot_outdated_at timestamp with time zone,
+    snapshot_scheduled_at timestamp with time zone,
+    snapshot_version integer NOT NULL
+);
+
+
+--
+-- Name: TABLE aggregates_that_need_snapshots; Type: COMMENT; Schema: sequent_schema; Owner: -
+--
+
+COMMENT ON TABLE sequent_schema.aggregates_that_need_snapshots IS 'Contains a row for every aggregate with more events than its snapshot threshold.';
+
+
+--
+-- Name: COLUMN aggregates_that_need_snapshots.snapshot_sequence_number_high_water_mark; Type: COMMENT; Schema: sequent_schema; Owner: -
+--
+
+COMMENT ON COLUMN sequent_schema.aggregates_that_need_snapshots.snapshot_sequence_number_high_water_mark IS 'The highest sequence number of the stored snapshot. Kept when snapshot are deleted to more easily query aggregates that need snapshotting the most';
+
+
+--
+-- Name: COLUMN aggregates_that_need_snapshots.snapshot_outdated_at; Type: COMMENT; Schema: sequent_schema; Owner: -
+--
+
+COMMENT ON COLUMN sequent_schema.aggregates_that_need_snapshots.snapshot_outdated_at IS 'Not NULL indicates a snapshot is needed since the stored timestamp';
+
+
+--
+-- Name: COLUMN aggregates_that_need_snapshots.snapshot_scheduled_at; Type: COMMENT; Schema: sequent_schema; Owner: -
+--
+
+COMMENT ON COLUMN sequent_schema.aggregates_that_need_snapshots.snapshot_scheduled_at IS 'Not NULL indicates a snapshot is in the process of being taken';
 
 
 --

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,18 +30,21 @@ CREATE TYPE sequent_schema.aggregate_event_type AS (
 
 
 --
--- Name: aggregates_that_need_snapshots(uuid, integer); Type: FUNCTION; Schema: sequent_schema; Owner: -
+-- Name: aggregates_that_need_snapshots(uuid, integer, jsonb); Type: FUNCTION; Schema: sequent_schema; Owner: -
 --
 
-CREATE FUNCTION sequent_schema.aggregates_that_need_snapshots(_last_aggregate_id uuid, _limit integer) RETURNS TABLE(aggregate_id uuid)
+CREATE FUNCTION sequent_schema.aggregates_that_need_snapshots(_last_aggregate_id uuid, _limit integer, _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb) RETURNS TABLE(aggregate_id uuid)
     LANGUAGE plpgsql
     SET search_path TO 'sequent_schema'
     AS $$
 BEGIN
   RETURN QUERY SELECT a.aggregate_id
-    FROM aggregates_that_need_snapshots a
-   WHERE a.snapshot_outdated_at IS NOT NULL
-     AND (_last_aggregate_id IS NULL OR a.aggregate_id > _last_aggregate_id)
+    FROM aggregates_that_need_snapshots s
+    JOIN aggregates a ON s.aggregate_id = a.aggregate_id
+    JOIN aggregate_types type ON a.aggregate_type_id = type.id
+   WHERE s.snapshot_outdated_at IS NOT NULL
+     AND s.snapshot_version = COALESCE((_snapshot_version_by_type->(type.type))::integer, 1)
+     AND (_last_aggregate_id IS NULL OR s.aggregate_id > _last_aggregate_id)
    ORDER BY 1
    LIMIT _limit;
 END;
@@ -66,23 +69,30 @@ $$;
 
 
 --
--- Name: delete_snapshots_before(uuid, integer, timestamp with time zone); Type: PROCEDURE; Schema: sequent_schema; Owner: -
+-- Name: delete_snapshots_before(uuid, integer, timestamp with time zone, jsonb); Type: PROCEDURE; Schema: sequent_schema; Owner: -
 --
 
-CREATE PROCEDURE sequent_schema.delete_snapshots_before(IN _aggregate_id uuid, IN _sequence_number integer, IN _now timestamp with time zone DEFAULT now())
+CREATE PROCEDURE sequent_schema.delete_snapshots_before(IN _aggregate_id uuid, IN _sequence_number integer, IN _now timestamp with time zone DEFAULT now(), IN _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb)
     LANGUAGE plpgsql
     SET search_path TO 'sequent_schema'
     AS $$
 BEGIN
-  DELETE FROM snapshot_records
+  DELETE FROM snapshot_records s
    WHERE aggregate_id = _aggregate_id
+     AND snapshot_version = COALESCE(
+           (SELECT _snapshot_version_by_type->(type.type)
+              FROM aggregates
+              JOIN aggregate_types type ON aggregate_type_id = type.id
+             WHERE s.aggregate_id = aggregates.aggregate_id)::integer,
+           1
+         )
      AND sequence_number < _sequence_number;
 
-  UPDATE aggregates_that_need_snapshots
+  UPDATE aggregates_that_need_snapshots a
      SET snapshot_outdated_at = _now
    WHERE aggregate_id = _aggregate_id
      AND snapshot_outdated_at IS NULL
-     AND NOT EXISTS (SELECT 1 FROM snapshot_records WHERE aggregate_id = _aggregate_id);
+     AND NOT EXISTS (SELECT 1 FROM snapshot_records s WHERE aggregate_id = _aggregate_id AND a.snapshot_version = s.snapshot_version);
 END;
 $$;
 
@@ -189,10 +199,10 @@ $$;
 
 
 --
--- Name: load_events(jsonb, boolean, timestamp with time zone); Type: FUNCTION; Schema: sequent_schema; Owner: -
+-- Name: load_events(jsonb, boolean, timestamp with time zone, jsonb); Type: FUNCTION; Schema: sequent_schema; Owner: -
 --
 
-CREATE FUNCTION sequent_schema.load_events(_aggregate_ids jsonb, _use_snapshots boolean DEFAULT true, _until timestamp with time zone DEFAULT NULL::timestamp with time zone) RETURNS SETOF sequent_schema.aggregate_event_type
+CREATE FUNCTION sequent_schema.load_events(_aggregate_ids jsonb, _use_snapshots boolean DEFAULT true, _until timestamp with time zone DEFAULT NULL::timestamp with time zone, _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb) RETURNS SETOF sequent_schema.aggregate_event_type
     LANGUAGE plpgsql
     SET search_path TO 'sequent_schema'
     AS $$
@@ -204,18 +214,25 @@ BEGIN
     -- in case transaction isolation level is lower than repeatable read (the default of
     -- PostgreSQL is read committed).
     RETURN QUERY WITH
-      aggregate AS (
+      aggregate AS MATERIALIZED (
         SELECT aggregate_types.type, aggregate_id, events_partition_key
           FROM aggregates
           JOIN aggregate_types ON aggregate_type_id = aggregate_types.id
          WHERE aggregate_id = _aggregate_id
       ),
-      snapshot AS (
+      snapshot AS MATERIALIZED (
         SELECT *
           FROM snapshot_records
          WHERE _use_snapshots
            AND aggregate_id = _aggregate_id
            AND (_until IS NULL OR created_at < _until)
+           AND snapshot_version = COALESCE(
+                 (SELECT snapshot_version_by_type.value
+                    FROM jsonb_each(_snapshot_version_by_type) AS snapshot_version_by_type(type, value)
+                    JOIN aggregate ON snapshot_records.aggregate_id = aggregate.aggregate_id
+                   WHERE aggregate.type = snapshot_version_by_type.type)::integer,
+                 1
+               )
          ORDER BY sequence_number DESC LIMIT 1
       )
     (SELECT a.*, s.snapshot_type, s.snapshot_json FROM aggregate a, snapshot s)
@@ -398,18 +415,25 @@ $$;
 
 
 --
--- Name: select_aggregates_for_snapshotting(integer, timestamp with time zone, timestamp with time zone); Type: FUNCTION; Schema: sequent_schema; Owner: -
+-- Name: select_aggregates_for_snapshotting(integer, timestamp with time zone, timestamp with time zone, jsonb); Type: FUNCTION; Schema: sequent_schema; Owner: -
 --
 
-CREATE FUNCTION sequent_schema.select_aggregates_for_snapshotting(_limit integer, _reschedule_snapshot_scheduled_before timestamp with time zone, _now timestamp with time zone DEFAULT now()) RETURNS TABLE(aggregate_id uuid)
+CREATE FUNCTION sequent_schema.select_aggregates_for_snapshotting(_limit integer, _reschedule_snapshot_scheduled_before timestamp with time zone, _now timestamp with time zone DEFAULT now(), _snapshot_version_by_type jsonb DEFAULT '{}'::jsonb) RETURNS TABLE(aggregate_id uuid)
     LANGUAGE plpgsql
     SET search_path TO 'sequent_schema'
     AS $$
 BEGIN
   RETURN QUERY WITH scheduled AS MATERIALIZED (
-    SELECT a.aggregate_id
-      FROM aggregates_that_need_snapshots AS a
+    SELECT s.aggregate_id
+      FROM aggregates_that_need_snapshots AS s
      WHERE snapshot_outdated_at IS NOT NULL
+       AND snapshot_version = COALESCE(
+             (SELECT _snapshot_version_by_type->(type.type)
+                FROM aggregates
+                JOIN aggregate_types type ON aggregate_type_id = type.id
+               WHERE s.aggregate_id = aggregates.aggregate_id)::integer,
+             1
+           )
      ORDER BY snapshot_outdated_at ASC, snapshot_sequence_number_high_water_mark DESC, aggregate_id ASC
      LIMIT _limit
        FOR UPDATE
@@ -465,9 +489,9 @@ BEGIN
 
     _snapshot_outdated_at = _aggregate->>'snapshot_outdated_at';
     IF _snapshot_outdated_at IS NOT NULL THEN
-      INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_outdated_at)
-      VALUES (_aggregate_id, _snapshot_outdated_at)
-          ON CONFLICT (aggregate_id) DO UPDATE
+      INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_version, snapshot_outdated_at)
+      VALUES (_aggregate_id, COALESCE((_aggregate->>'snapshot_version')::integer, 1), _snapshot_outdated_at)
+          ON CONFLICT (aggregate_id, snapshot_version) DO UPDATE
          SET snapshot_outdated_at = LEAST(row.snapshot_outdated_at, EXCLUDED.snapshot_outdated_at)
        WHERE row.snapshot_outdated_at IS DISTINCT FROM EXCLUDED.snapshot_outdated_at;
     END IF;
@@ -588,23 +612,26 @@ CREATE PROCEDURE sequent_schema.store_snapshots(IN _snapshots jsonb)
 DECLARE
   _aggregate_id uuid;
   _snapshot jsonb;
+  _snapshot_version integer;
   _sequence_number snapshot_records.sequence_number%TYPE;
 BEGIN
   FOR _snapshot IN SELECT * FROM jsonb_array_elements(_snapshots) LOOP
     _aggregate_id = _snapshot->>'aggregate_id';
     _sequence_number = _snapshot->'sequence_number';
+    _snapshot_version = _snapshot->'snapshot_version';
 
-    INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_sequence_number_high_water_mark)
-    VALUES (_aggregate_id, _sequence_number)
-        ON CONFLICT (aggregate_id) DO UPDATE
+    INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_version, snapshot_sequence_number_high_water_mark)
+    VALUES (_aggregate_id, _snapshot_version, _sequence_number)
+        ON CONFLICT (aggregate_id, snapshot_version) DO UPDATE
        SET snapshot_sequence_number_high_water_mark =
              GREATEST(row.snapshot_sequence_number_high_water_mark, EXCLUDED.snapshot_sequence_number_high_water_mark),
            snapshot_outdated_at = NULL,
            snapshot_scheduled_at = NULL;
 
-    INSERT INTO snapshot_records (aggregate_id, sequence_number, created_at, snapshot_type, snapshot_json)
+    INSERT INTO snapshot_records (aggregate_id, snapshot_version, sequence_number, created_at, snapshot_type, snapshot_json)
     VALUES (
       _aggregate_id,
+      _snapshot_version,
       _sequence_number,
       (_snapshot->>'created_at')::timestamptz,
       _snapshot->>'snapshot_type',
@@ -788,7 +815,8 @@ CREATE TABLE sequent_schema.aggregates_that_need_snapshots (
     aggregate_id uuid NOT NULL,
     snapshot_sequence_number_high_water_mark integer,
     snapshot_outdated_at timestamp with time zone,
-    snapshot_scheduled_at timestamp with time zone
+    snapshot_scheduled_at timestamp with time zone,
+    snapshot_version integer NOT NULL
 );
 
 
@@ -992,7 +1020,8 @@ CREATE TABLE sequent_schema.snapshot_records (
     sequence_number integer NOT NULL,
     created_at timestamp with time zone NOT NULL,
     snapshot_type text NOT NULL,
-    snapshot_json jsonb NOT NULL
+    snapshot_json jsonb NOT NULL,
+    snapshot_version integer NOT NULL
 );
 
 
@@ -1115,7 +1144,7 @@ ALTER TABLE ONLY sequent_schema.aggregates_default
 --
 
 ALTER TABLE ONLY sequent_schema.aggregates_that_need_snapshots
-    ADD CONSTRAINT aggregates_that_need_snapshots_pkey PRIMARY KEY (aggregate_id);
+    ADD CONSTRAINT aggregates_that_need_snapshots_pkey PRIMARY KEY (aggregate_id, snapshot_version);
 
 
 --
@@ -1203,7 +1232,7 @@ ALTER TABLE ONLY sequent_schema.saved_event_records
 --
 
 ALTER TABLE ONLY sequent_schema.snapshot_records
-    ADD CONSTRAINT snapshot_records_pkey PRIMARY KEY (aggregate_id, sequence_number);
+    ADD CONSTRAINT snapshot_records_pkey PRIMARY KEY (aggregate_id, snapshot_version, sequence_number);
 
 
 --
@@ -1446,11 +1475,11 @@ ALTER TABLE sequent_schema.events
 
 
 --
--- Name: snapshot_records snapshot_records_aggregate_id_fkey; Type: FK CONSTRAINT; Schema: sequent_schema; Owner: -
+-- Name: snapshot_records snapshot_records_aggregate_id_snapshot_version_fkey; Type: FK CONSTRAINT; Schema: sequent_schema; Owner: -
 --
 
 ALTER TABLE ONLY sequent_schema.snapshot_records
-    ADD CONSTRAINT snapshot_records_aggregate_id_fkey FOREIGN KEY (aggregate_id) REFERENCES sequent_schema.aggregates_that_need_snapshots(aggregate_id) ON UPDATE CASCADE ON DELETE CASCADE;
+    ADD CONSTRAINT snapshot_records_aggregate_id_snapshot_version_fkey FOREIGN KEY (aggregate_id, snapshot_version) REFERENCES sequent_schema.aggregates_that_need_snapshots(aggregate_id, snapshot_version) ON UPDATE CASCADE ON DELETE CASCADE;
 
 
 --
@@ -1461,9 +1490,9 @@ SET search_path TO public,view_schema,sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20250512135500'),
+('20250509133000'),
 ('20250509120000'),
 ('20250501120000'),
 ('20250312105100'),
 ('20250101000001'),
 ('20250101000000');
-

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -24,6 +24,7 @@ CREATE TYPE sequent_schema.aggregate_event_type AS (
 	aggregate_type text,
 	aggregate_id uuid,
 	events_partition_key text,
+	event_sequence_number integer,
 	event_type text,
 	event_json jsonb
 );
@@ -186,6 +187,7 @@ BEGIN
   RETURN QUERY SELECT aggregate_types.type,
          a.aggregate_id,
          a.events_partition_key,
+         e.sequence_number,
          event_types.type,
          enrich_event_json(e)
     FROM aggregates a
@@ -229,15 +231,15 @@ BEGIN
            AND snapshot_version = COALESCE((_snapshot_version_by_type->(aggregate.type))::integer, 1)
          ORDER BY s.sequence_number DESC LIMIT 1
       )
-    (SELECT a.*, s.snapshot_type, s.snapshot_json FROM aggregate a, snapshot s)
+    SELECT a.*, 0 AS sequence_number, s.snapshot_type, s.snapshot_json FROM aggregate a, snapshot s
     UNION ALL
-    (SELECT a.*, event_types.type, enrich_event_json(e)
+    SELECT a.*, e.sequence_number, event_types.type, enrich_event_json(e)
        FROM aggregate a
        JOIN events e ON (a.events_partition_key, a.aggregate_id) = (e.partition_key, e.aggregate_id)
        JOIN event_types ON e.event_type_id = event_types.id
       WHERE e.sequence_number >= COALESCE((SELECT sequence_number FROM snapshot), 0)
         AND (_until IS NULL OR e.created_at < _until)
-      ORDER BY e.sequence_number ASC);
+    ORDER BY sequence_number ASC;
   END LOOP;
 END;
 $$;
@@ -254,6 +256,7 @@ CREATE FUNCTION sequent_schema.load_latest_snapshot(_aggregate_id uuid, _snapsho
   SELECT t.type,
          a.aggregate_id,
          a.events_partition_key,
+         0 AS sequence_number,
          s.snapshot_type,
          s.snapshot_json
     FROM aggregates a

--- a/docs/docs/concepts/snapshotting.md
+++ b/docs/docs/concepts/snapshotting.md
@@ -9,7 +9,7 @@ Sequent supports snapshots on Aggregates that call `enable_snapshots` with a def
 
 ```ruby
 class UserNames < Sequent::AggregateRoot
-  enable_snapshots default_threshold: 100
+  enable_snapshots default_threshold: 100, version: 1
 end
 ```
 
@@ -22,7 +22,17 @@ You can schedule this task to run in the background regularly as it
 will simply do nothing if there are no aggregates that need a new
 snapshot.
 
-**Important:** When you enable snapshotting you **must** delete all snapshots after each deploy. The AggregateRoot root state is dumped in the database. If there is a new version of an AggregateRoot class definition, the snapshotted state can not be loaded.
-{: .notice--danger}
+**Important:** The snapshot format is versioned, with the default
+version being 1. If the implementation of an aggregate changes (e.g. a
+new field is added, or a hash changed into an array, etc) the snapshot
+format becomes incompatible and the version must be increased. This
+ensures the new implementation will not try to use the old snapshot
+format.
+
+Alternatively, you can delete all snapshots whenever a new
+version of your application is deployed. This will cause a temporary
+drop in performance when loading previously snapshotted aggregates,
+since all events will have to be reloaded and replayed when an
+aggregate is accessed.
 
 To delete all snapshots, you can execute `bundle exec rake sequent:snapshotting:delete_all`.

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -41,6 +41,10 @@ module Sequent
 
     DEFAULT_TIME_PRECISION = ActiveSupport::JSON::Encoding.time_precision
 
+    DEFAULT_AGGREGATE_SNAPSHOT_VERSIONS = proc do |clazz|
+      Sequent::Core::AggregateRoots.snapshot_version_by_type(clazz)
+    end
+
     attr_accessor :aggregate_repository,
                   :event_store,
                   :command_service,
@@ -72,7 +76,8 @@ module Sequent
                   :primary_database_role,
                   :primary_database_key,
                   :time_precision,
-                  :enable_autoregistration
+                  :enable_autoregistration,
+                  :aggregate_snapshot_versions
 
     attr_reader :migrations_class_name,
                 :versions_table_name
@@ -134,6 +139,7 @@ module Sequent
       self.time_precision = DEFAULT_TIME_PRECISION
 
       self.enable_autoregistration = false
+      self.aggregate_snapshot_versions = DEFAULT_AGGREGATE_SNAPSHOT_VERSIONS
     end
 
     def can_use_multiple_databases?

--- a/lib/sequent/core/aggregate_roots.rb
+++ b/lib/sequent/core/aggregate_roots.rb
@@ -14,6 +14,12 @@ module Sequent
         def all
           aggregate_roots
         end
+
+        def snapshot_version_by_type(clazz = Sequent::Core::AggregateRoot)
+          base_class = clazz || Sequent::Core::AggregateRoot
+          matching_aggregate_types = [base_class, *base_class.descendants].filter(&:snapshots_enabled?)
+          matching_aggregate_types.to_h { |type| [type, type.snapshot_version] }
+        end
       end
     end
   end

--- a/lib/sequent/core/event.rb
+++ b/lib/sequent/core/event.rb
@@ -48,7 +48,7 @@ module Sequent
     end
 
     class SnapshotEvent < Event
-      attrs data: String
+      attrs snapshot_version: Integer, data: String
     end
   end
 end

--- a/lib/sequent/core/snapshot_store.rb
+++ b/lib/sequent/core/snapshot_store.rb
@@ -5,6 +5,8 @@ require_relative 'helpers/pgsql_helpers'
 
 module Sequent
   module Core
+    AggregateSnapshotNeeded = Data.define(:aggregate_id, :snapshot_version)
+
     module SnapshotStore
       include Helpers::PgsqlHelpers
 
@@ -174,8 +176,9 @@ module Sequent
           connection,
           'select_aggregates_for_snapshotting',
           [limit, reschedule_snapshots_scheduled_before, Time.now, snapshot_version_by_type.to_json],
-          columns: ['aggregate_id'],
-        ).pluck('aggregate_id')
+        )
+          .pluck(*AggregateSnapshotNeeded.members.map(&:name))
+          .map { |row| AggregateSnapshotNeeded.new(*row) }
       end
 
       private

--- a/lib/sequent/core/snapshot_store.rb
+++ b/lib/sequent/core/snapshot_store.rb
@@ -81,28 +81,6 @@ module Sequent
         EOS
       end
 
-      def mark_aggregates_with_lower_snapshot_versions_for_snapshotting
-        sql = <<~SQL
-          INSERT INTO aggregates_that_need_snapshots (aggregate_id, snapshot_version, snapshot_sequence_number_high_water_mark, snapshot_outdated_at)
-          SELECT source.aggregate_id,
-                 ($1::jsonb->>(t.type))::integer,
-                 MAX(snapshot_sequence_number_high_water_mark),
-                 MIN(snapshot_outdated_at)
-            FROM aggregates_that_need_snapshots source
-            JOIN aggregates a ON source.aggregate_id = a.aggregate_id
-            JOIN aggregate_types t ON a.aggregate_type_id = t.id
-           WHERE source.snapshot_version < ($1::jsonb->>(t.type))::integer
-           GROUP BY 1, 2
-              ON CONFLICT DO NOTHING;
-        SQL
-
-        connection.exec_update(
-          sql,
-          'mark_aggregates_with_lower_snapshot_versions_for_snapshotting',
-          [snapshot_version_by_type.to_json],
-        )
-      end
-
       # Deletes all snapshots for aggregate_id with a sequence_number lower than the specified sequence number.
       def delete_snapshots_before(aggregate_id, sequence_number)
         call_procedure(

--- a/lib/sequent/core/snapshot_store.rb
+++ b/lib/sequent/core/snapshot_store.rb
@@ -5,7 +5,7 @@ require_relative 'helpers/pgsql_helpers'
 
 module Sequent
   module Core
-    AggregateSnapshotNeeded = Data.define(:aggregate_id, :snapshot_version)
+    AggregateSnapshotNeeded = Data.define(:aggregate_id, :aggregate_type, :snapshot_version)
 
     module SnapshotStore
       include Helpers::PgsqlHelpers

--- a/lib/sequent/core/stream_record.rb
+++ b/lib/sequent/core/stream_record.rb
@@ -9,10 +9,11 @@ module Sequent
       :aggregate_id,
       :events_partition_key,
       :snapshot_outdated_at,
+      :snapshot_version,
       :unique_keys,
     ) do
       def initialize(aggregate_type:, aggregate_id:, events_partition_key: '', snapshot_outdated_at: nil,
-                     unique_keys: {})
+                     snapshot_version: 1, unique_keys: {})
         super
       end
     end

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -64,6 +64,19 @@ module Sequent
               Sequent.configuration.event_store.register_types!
               Sequent.logger.info 'Registered aggregate root, command, and event types'
             end
+
+            desc <<~EOS
+              Register the required snapshot version for each aggregate root. This will ensure the snapshotter
+              starts snapshotting with the right snapshot version.
+
+              NOTE make sure to load all Ruby classes before running this task!
+            EOS
+            task snapshot_versions: %i[sequent:connect] do
+              ensure_sequent_env_set!
+
+              Sequent.configuration.event_store.register_snapshot_versions!
+              Sequent.logger.info 'Registered required snapshot versions'
+            end
           end
 
           desc 'Creates sequent view schema if not exists and runs internal migrations'

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -391,8 +391,8 @@ module Sequent
             desc <<~EOS
               Delete all aggregate snapshots with a lower snapshot version than currently supported.
             EOS
-            task delete_older_versions: :connect do
-              Sequent.configuration.event_store.delete_lower_snapshot_versions
+            task delete_unknown_snapshot_versions: :connect do
+              Sequent.configuration.event_store.delete_unknown_snapshot_versions
               Sequent.logger.info 'Deleted all lower snapshot versions from the event store'
             end
           end

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -358,11 +358,13 @@ module Sequent
                      'usage rake sequent:snapshots:take_snapshots[limit]'
               end
 
-              aggregate_ids = Sequent.configuration.event_store.select_aggregates_for_snapshotting(limit:)
+              aggregates = Sequent.configuration.event_store.select_aggregates_for_snapshotting(limit:)
 
-              Sequent.logger.info "Taking #{aggregate_ids.size} snapshots"
-              aggregate_ids.each do |aggregate_id|
-                Sequent.command_service.execute_commands(Sequent::Core::TakeSnapshot.new(aggregate_id:))
+              Sequent.logger.info "Taking #{aggregates.size} snapshots"
+              aggregates.each do |aggregate|
+                Sequent.command_service.execute_commands(
+                  Sequent::Core::TakeSnapshot.new(aggregate_id: aggregate.aggregate_id),
+                )
               end
             end
 

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -374,6 +374,14 @@ module Sequent
               Sequent.configuration.event_store.delete_all_snapshots
               Sequent.logger.info 'Deleted all aggregate snapshots from the event store'
             end
+
+            desc <<~EOS
+              Delete all aggregate snapshots with a lower snapshot version than currently supported.
+            EOS
+            task delete_older_versions: :connect do
+              Sequent.configuration.event_store.delete_lower_snapshot_versions
+              Sequent.logger.info 'Deleted all lower snapshot versions from the event store'
+            end
           end
         end
       end

--- a/spec/lib/sequent/core/aggregate_repository_spec.rb
+++ b/spec/lib/sequent/core/aggregate_repository_spec.rb
@@ -387,6 +387,8 @@ describe Sequent::Core::AggregateRepository do
     class DummyAggregate3 < Sequent::Core::AggregateRoot
       attr_reader :pinged
 
+      enable_snapshots
+
       def initialize(id)
         super
         apply DummyCreated

--- a/spec/lib/sequent/core/aggregate_repository_spec.rb
+++ b/spec/lib/sequent/core/aggregate_repository_spec.rb
@@ -101,7 +101,7 @@ describe Sequent::Core::AggregateRepository do
           ],
         ],
       )
-      expect { repository.load_aggregate(:id, Integer) }.to raise_error TypeError
+      expect { repository.load_aggregate(:id, DummyAggregate2) }.to raise_error TypeError
     end
 
     it 'should commit and clear events from aggregates in the identity map' do
@@ -305,7 +305,7 @@ describe Sequent::Core::AggregateRepository do
                 .once,
             )
 
-          expect { repository.load_aggregates([aggregate.id], Integer) }.to raise_error TypeError
+          expect { repository.load_aggregates([aggregate.id], DummyAggregate2) }.to raise_error TypeError
         end
 
         it 'fails if one if the aggregates in the events store is not of the requested type' do

--- a/spec/lib/sequent/core/aggregate_snapshotter_spec.rb
+++ b/spec/lib/sequent/core/aggregate_snapshotter_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe Sequent::Core::AggregateSnapshotter do
   class MyEvent < Sequent::Core::Event; end
-  class MyAggregate < Sequent::Core::AggregateRoot; end
+  class MyAggregate2 < Sequent::Core::AggregateRoot; end
 
   let(:command_handler) { described_class.new }
   let(:event_store) { Sequent.configuration.event_store }

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -10,6 +10,7 @@ describe Sequent::Core::EventStore do
   end
 
   class MyAggregate < Sequent::Core::AggregateRoot
+    enable_snapshots version: 42
   end
 
   let(:event_store) { Sequent.configuration.event_store }
@@ -68,7 +69,7 @@ describe Sequent::Core::EventStore do
 
     let(:aggregate) do
       stream, events = event_store.load_events(aggregate_id)
-      Sequent::Core::AggregateRoot.load_from_history(stream, events)
+      MyAggregate.load_from_history(stream, events)
     end
 
     let(:snapshot) do

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -315,7 +315,7 @@ describe Sequent::Core::EventStore do
         MyAggregate.enable_snapshots version: 3
         expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to be_empty
 
-        subject.mark_aggregates_with_lower_snapshot_versions_for_snapshotting
+        subject.register_snapshot_versions!
         expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to contain_exactly(
           Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 3),
         )

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -230,16 +230,14 @@ describe Sequent::Core::EventStore do
 
       it 'can delete lower snapshot versions' do
         event_store.store_snapshots([snapshot_v1, snapshot_v2])
-        MyAggregate.enable_snapshots version: 1
-        expect { subject.delete_lower_snapshot_versions }.to change(SnapshotRecord, :count).by(0)
 
         MyAggregate.enable_snapshots version: 2
-        expect { subject.delete_lower_snapshot_versions }.to change(SnapshotRecord, :count).by(-1)
+        expect { subject.delete_unknown_snapshot_versions }.to change(SnapshotRecord, :count).by(-1)
 
         expect(SnapshotRecord.find_by(aggregate_id:)).to have_attributes(snapshot_version: 2)
 
         MyAggregate.enable_snapshots version: 3
-        expect { subject.delete_lower_snapshot_versions }.to change(SnapshotRecord, :count).by(-1)
+        expect { subject.delete_unknown_snapshot_versions }.to change(SnapshotRecord, :count).by(-1)
       end
 
       it 'loads the event stream using the correct snapshot version' do

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -137,14 +137,14 @@ describe Sequent::Core::EventStore do
       )
 
       expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to include(
-        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 42),
+        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 42),
       )
       expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to be_empty
 
       event_store.store_snapshots([snapshot])
 
       expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to include(
-        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id_2, 42),
+        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id_2, MyAggregate.name, 42),
       )
       expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to be_empty
 
@@ -156,8 +156,8 @@ describe Sequent::Core::EventStore do
 
       expect(event_store.select_aggregates_for_snapshotting(limit: 10, reschedule_snapshots_scheduled_before: Time.now))
         .to include(
-          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 42),
-          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id_2, 42),
+          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 42),
+          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id_2, MyAggregate.name, 42),
         )
     end
 
@@ -192,7 +192,7 @@ describe Sequent::Core::EventStore do
       expect(event_store.load_latest_snapshot(aggregate_id)).to eq(nil)
       expect(event_store.aggregates_that_need_snapshots(nil)).to include(aggregate_id)
       expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to include(
-        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 42),
+        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 42),
       )
     end
 
@@ -208,7 +208,7 @@ describe Sequent::Core::EventStore do
       expect(event_store.load_latest_snapshot(aggregate_id)).to eq(nil)
       expect(event_store.aggregates_that_need_snapshots(nil)).to include(aggregate_id)
       expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to include(
-        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 42),
+        Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 42),
       )
     end
 
@@ -276,7 +276,7 @@ describe Sequent::Core::EventStore do
 
         MyAggregate.enable_snapshots version: 2
         expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to contain_exactly(
-          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 2),
+          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 2),
         )
       end
 
@@ -306,7 +306,7 @@ describe Sequent::Core::EventStore do
         )
 
         expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to contain_exactly(
-          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 2),
+          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 2),
         )
 
         MyAggregate.enable_snapshots version: 1
@@ -317,7 +317,7 @@ describe Sequent::Core::EventStore do
 
         subject.register_snapshot_versions!
         expect(event_store.select_aggregates_for_snapshotting(limit: 1)).to contain_exactly(
-          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, 3),
+          Sequent::Core::AggregateSnapshotNeeded.new(aggregate_id, MyAggregate.name, 3),
         )
       end
     end


### PR DESCRIPTION
To support changing the internals of an aggregate root without having
to throw away the old snapshots the snapshot version can now be
specified. This is needed to be able to support zero-downtime
deployments, where both old and new code run concurrently using the
same event store, but each may require different snapshots.

Example usage:

```
enable_snapshots version: 2
```

The default version is 1.

A hash mapping aggregate types to the supported snapshot version is
passed to every database call that needs it so the snapshot can be
correctly selected. The default implementation queries all descendants
of `AggregateRoot` for the supported snapshot version. This can be
changed using the `aggregate_snapshot_versions` configuration setting.