### PR TITLE
Make applying partition key changes more robust

### DIFF
--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -308,11 +308,12 @@ module Sequent
                      'usage rake sequent:aggregates:update_partition_keys[limit]'
               end
 
-              count = Sequent::Internal::PartitionKeyChange.count
-              Sequent.logger.info "Applying #{count} partition key changes (limited to #{limit})"
+              total_count = Sequent::Internal::PartitionKeyChange.count
+              Sequent.logger.info "Applying #{total_count} partition key changes (limited to #{limit})"
 
               begin
-                Sequent::Internal::PartitionKeyChange.update_aggregate_partition_keys(limit:)
+                applied_count = Sequent::Internal::PartitionKeyChange.update_aggregate_partition_keys(limit:)
+                Sequent.logger.info "Applied #{applied_count} out of #{total_count} partition key changes"
               rescue Sequent::Migrations::ConcurrentMigration
                 Sequent.logger.error 'View schema migration is active so not updating partition keys'
               end

--- a/spec/lib/sequent/internal/partitioned_storage_spec.rb
+++ b/spec/lib/sequent/internal/partitioned_storage_spec.rb
@@ -80,7 +80,8 @@ module Sequent
         end
 
         it 'updates the aggregate and events using a maintenance task' do
-          PartitionKeyChange.update_aggregate_partition_keys(limit: 10)
+          applied_count = PartitionKeyChange.update_aggregate_partition_keys(limit: 10)
+          expect(applied_count).to eq(1)
 
           logged_change = PartitionKeyChange.find_by(aggregate_id:)
           expect(logged_change).to be_nil


### PR DESCRIPTION
Lock the partition key change and skip if locked, limit statement duration and log number of changes applied.