### PR TITLE
Drop indexes before replaying, re-create, vacuum, analyze after

### DIFF
--- a/db/migrate/20250815103000_sequent_add_index_definitions_to_replay_states.rb
+++ b/db/migrate/20250815103000_sequent_add_index_definitions_to_replay_states.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class SequentAddIndexDefinitionsToReplayStates < ActiveRecord::Migration[7.2]
+  def change
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      add_column :replay_states, :index_definitions, :jsonb
+      add_column :replay_states, :table_cluster_indexes, :jsonb
+      remove_check_constraint :replay_states, name: 'valid_replay_state'
+      add_check_constraint :replay_states, <<~SQL, name: 'valid_replay_state'
+        state IN ('created', 'prepared', 'initial_replay', 'initial_replay_completed', 'incremental_replay', 'prepare_for_activation', 'ready_for_activation', 'failed', 'done', 'aborted')
+      SQL
+    end
+  end
+end

--- a/db/migrate/20250815103000_sequent_add_index_definitions_to_replay_states.rb
+++ b/db/migrate/20250815103000_sequent_add_index_definitions_to_replay_states.rb
@@ -9,6 +9,8 @@ class SequentAddIndexDefinitionsToReplayStates < ActiveRecord::Migration[7.2]
       add_check_constraint :replay_states, <<~SQL, name: 'valid_replay_state'
         state IN ('created', 'prepared', 'initial_replay', 'initial_replay_completed', 'incremental_replay', 'prepare_for_activation', 'ready_for_activation', 'failed', 'done', 'aborted')
       SQL
+      remove_check_constraint :projector_states, name: 'replaying_newer_then_active'
+      remove_check_constraint :projector_states, name: 'activating_newer_than_active'
     end
   end
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1021,7 +1021,9 @@ CREATE TABLE sequent_schema.replay_states (
     continue_replay_at_xact_id bigint,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT valid_replay_state CHECK ((state = ANY (ARRAY['created'::text, 'prepared'::text, 'initial_replay'::text, 'incremental_replay'::text, 'ready_for_activation'::text, 'failed'::text, 'done'::text, 'aborted'::text])))
+    index_definitions jsonb,
+    table_cluster_indexes jsonb,
+    CONSTRAINT valid_replay_state CHECK ((state = ANY (ARRAY['created'::text, 'prepared'::text, 'initial_replay'::text, 'initial_replay_completed'::text, 'incremental_replay'::text, 'prepare_for_activation'::text, 'ready_for_activation'::text, 'failed'::text, 'done'::text, 'aborted'::text])))
 );
 
 
@@ -1572,6 +1574,7 @@ ALTER TABLE ONLY sequent_schema.snapshot_records
 SET search_path TO public,view_schema,sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250815103000'),
 ('20250630113000'),
 ('20250601120000'),
 ('20250512135500'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1004,9 +1004,7 @@ CREATE TABLE sequent_schema.projector_states (
     replaying_version integer,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT activating_newer_than_active CHECK ((activating_version > active_version)),
-    CONSTRAINT replaying_conflicts_with_activating CHECK (((replaying_version IS NULL) OR (activating_version IS NULL))),
-    CONSTRAINT replaying_newer_then_active CHECK ((replaying_version > active_version))
+    CONSTRAINT replaying_conflicts_with_activating CHECK (((replaying_version IS NULL) OR (activating_version IS NULL)))
 );
 
 

--- a/lib/sequent/core/projector.rb
+++ b/lib/sequent/core/projector.rb
@@ -50,6 +50,11 @@ module Sequent
 
       def self.included(host_class)
         host_class.extend(ClassMethods)
+
+        host_class.class_attribute :additional_replay_indexes,
+                                   default: [],
+                                   instance_reader: false,
+                                   instance_writer: false
       end
 
       def self.none

--- a/lib/sequent/core/projectors.rb
+++ b/lib/sequent/core/projectors.rb
@@ -64,6 +64,13 @@ module Sequent
           update_projector_state(rows)
         end
 
+        def abort_replaying_projectors(projector_classes)
+          rows = projector_classes.map do |c|
+            {name: c.name, activating_version: nil, replaying_version: nil}
+          end
+          update_projector_state(rows)
+        end
+
         def projector_states
           cached = Thread.current[PROJECTOR_STATES_KEY]
           return cached unless cached.nil?

--- a/lib/sequent/migrations/projectors_replayer.rb
+++ b/lib/sequent/migrations/projectors_replayer.rb
@@ -375,7 +375,8 @@ module Sequent
              AND NOT i.indisprimary
              AND NOT i.indisexclusion
         SQL
-        droppable_indexes = disposable_indexes - @projector_classes.flat_map(&:additional_replay_indexes).map(&:to_s)
+        additional_replay_indexes = /^#{Regexp.union(@projector_classes.map(&:additional_replay_indexes).flatten)}$/
+        droppable_indexes = disposable_indexes.grep_v(additional_replay_indexes)
         droppable_indexes.each do |index_name|
           exec_update("DROP INDEX #{quoted_replay_schema_name}.#{quote_table_name(index_name)}")
         end

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -105,7 +105,11 @@ module Sequent
                 old_dump_schemas = ActiveRecord.dump_schemas
                 begin
                   ActiveRecord.dump_schemas = nil
-                  DatabaseTasks.structure_dump_flags = "--exclude-schema=#{Sequent.configuration.view_schema_name}"
+                  ActiveRecord::Tasks::DatabaseTasks.structure_dump_flags = %W[
+                    --exclude-schema=#{Sequent.configuration.view_schema_name}
+                    --exclude-schema=#{Sequent.configuration.replay_schema_name}
+                    --exclude-schema=#{Sequent.configuration.archive_schema_name}
+                  ]
                   DatabaseTasks.dump_schema(db_config, :sql)
                 ensure
                   ActiveRecord.dump_schemas = old_dump_schemas

--- a/spec/lib/sequent/migrations/projectors_replayer_spec.rb
+++ b/spec/lib/sequent/migrations/projectors_replayer_spec.rb
@@ -117,7 +117,7 @@ describe Sequent::Migrations::ProjectorsReplayer do
     it 'should fail if already prepared' do
       expect do
         subject.prepare_for_replay
-      end.to raise_error(/when current state is `created`/)
+      end.to raise_error(/when current state is created/)
     end
   end
 
@@ -156,7 +156,7 @@ describe Sequent::Migrations::ProjectorsReplayer do
       subject.done!
 
       expect { subject.perform_initial_replay }
-        .to raise_error(/initial replay can only be performed when current state is `prepared`/)
+        .to raise_error(/initial replay can only be performed when current state is prepared/)
     end
 
     it 'should ensure the replay tables are empty for the initial replay' do
@@ -180,8 +180,8 @@ describe Sequent::Migrations::ProjectorsReplayer do
         expect(record_count('view_schema')).to eq(initial_event_count)
       end
 
-      it 'should be ready for incremental replay and activation' do
-        expect(replay_state).to have_attributes(state: 'ready_for_activation')
+      it 'should be ready for incremental replay and or preparing for activation' do
+        expect(replay_state).to have_attributes(state: 'initial_replay_completed')
       end
 
       context '#incremental_replay' do
@@ -211,6 +211,12 @@ describe Sequent::Migrations::ProjectorsReplayer do
 
           expect(record_count('replay_schema')).to eq(initial_event_count + incremental_event_count)
         end
+
+        it 'can be executed after preparing for activation' do
+          subject.prepare_for_activation!
+
+          subject.perform_incremental_replay
+        end
       end
     end
   end
@@ -220,7 +226,7 @@ describe Sequent::Migrations::ProjectorsReplayer do
 
     it 'requires initial replay to have been completed' do
       expect { subject.activate! }
-        .to raise_error(/activation can only be performed when current state is `ready_for_activation`/)
+        .to raise_error(/activation can only be performed when current state is ready_for_activation/)
     end
 
     context 'when ready for activation' do
@@ -229,6 +235,7 @@ describe Sequent::Migrations::ProjectorsReplayer do
       before do
         insert_events(initial_event_count)
         subject.perform_initial_replay
+        subject.prepare_for_activation!
       end
 
       after do


### PR DESCRIPTION
Replaying without indexes speeds up replaying significantly. By default all indexes that are not used for primary key, unique, or exclusion constraints are dropped before replay.

You can use `self.additional_replay_indexes = %w[my_index_name]` to keep additional indexes that your projector needs (maybe to look up rows or validate foreign key constraints).

Before activating the replayed tables the tables are vacuumed or clustered, the dropped indexes are re-created and then all tables and indexes are analyzed.