### PR TITLE
Add rake task to deactivate unknown projectors

### DIFF
--- a/lib/sequent/core/projectors.rb
+++ b/lib/sequent/core/projectors.rb
@@ -36,6 +36,16 @@ module Sequent
           update_projector_state(rows)
         end
 
+        def deactivate_unknown_projectors!(known_projector_classes: Sequent::Core::Migratable.projectors)
+          transaction_provider.transactional do
+            lock_projector_states_for_update
+
+            ProjectorState
+              .where.not(name: known_projector_classes.map(&:name))
+              .update_all(active_version: nil)
+          end
+        end
+
         def register_inactive_projectors!(projector_classes)
           rows = projector_classes.map do |c|
             {name: c.name, active_version: nil, replaying_version: nil, activating_version: nil}

--- a/lib/sequent/rake/migration_tasks.rb
+++ b/lib/sequent/rake/migration_tasks.rb
@@ -409,6 +409,17 @@ module Sequent
               Sequent::Core::Projectors.deactivate_projectors!(args.extras)
             end
 
+            desc <<~EOS
+              Deactivates projectors that are not registered in the Sequent configuration
+
+              The managed tables are NOT removed or deleted so the data remains but is no longer updated
+              when new events arrive.
+            EOS
+            task deactivate_unknown_projectors: :connect do
+              known_projector_classes = Sequent::Core::Migratable.projectors
+              Sequent::Core::Projectors.deactivate_unknown_projectors!(known_projector_classes:)
+            end
+
             namespace :replay do
               desc 'shows the current replay status'
               task status: :connect do

--- a/spec/lib/sequent/core/projectors_spec.rb
+++ b/spec/lib/sequent/core/projectors_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Sequent::Core::Projectors do
+  subject { Sequent::Core::Projectors }
+  class SomeProjectorClass < Sequent::Core::Projector
+    self.skip_autoregister = true
+  end
+  class AnotherProjectorClass < Sequent::Core::Projector
+    self.skip_autoregister = true
+  end
+
+  context 'registration' do
+    it 'manages active projector registrations' do
+      subject.register_inactive_projectors!([SomeProjectorClass, AnotherProjectorClass])
+      expect(subject.projector_states).to include(
+        'SomeProjectorClass' => have_attributes(active_version: nil),
+        'AnotherProjectorClass' => have_attributes(active_version: nil),
+      )
+
+      subject.register_active_projectors!([SomeProjectorClass, AnotherProjectorClass])
+      expect(subject.projector_states).to include(
+        'SomeProjectorClass' => have_attributes(active_version: 1),
+        'AnotherProjectorClass' => have_attributes(active_version: 1),
+      )
+
+      subject.deactivate_unknown_projectors!(known_projector_classes: [AnotherProjectorClass])
+      expect(subject.projector_states).to include(
+        'SomeProjectorClass' => have_attributes(active_version: nil),
+        'AnotherProjectorClass' => have_attributes(active_version: 1),
+      )
+    end
+  end
+end


### PR DESCRIPTION
This allows deactivating removed projectors after a new version is deployed. Otherwise all projectors start failing due to the presence of an unknown, active projector.