### PR TITLE
Projector version should inherit from superclass

### DIFF
--- a/lib/sequent/core/projector.rb
+++ b/lib/sequent/core/projector.rb
@@ -30,7 +30,7 @@ module Sequent
         end
 
         def version
-          @version || Sequent.migrations_class&.version || 1
+          @version || version_from_superclass || Sequent.migrations_class&.version || 1
         end
 
         private
@@ -41,6 +41,10 @@ module Sequent
 
         def manages_no_tables_from_superclass?
           superclass.manages_no_tables? if superclass.respond_to?(:manages_no_tables?)
+        end
+
+        def version_from_superclass
+          superclass.version if superclass.respond_to?(:version)
         end
       end
 

--- a/spec/lib/sequent/core/projector_spec.rb
+++ b/spec/lib/sequent/core/projector_spec.rb
@@ -33,6 +33,35 @@ describe Sequent::Core::Projector do
     end.to raise_error(Sequent::Core::Projector::NotManagedByThisProjector)
   end
 
+  context 'versioning' do
+    let(:parent_projector_class) do
+      Class.new(Sequent::Core::Projector) do
+        self.version = 3
+      end
+    end
+
+    it 'should default to 1 if not specified' do
+      projector_class = Class.new(Sequent::Core::Projector)
+
+      expect(projector_class.version).to eq(1)
+    end
+
+    it 'should inherit the version from the superclass' do
+      child_projector_class = Class.new(parent_projector_class)
+
+      expect(child_projector_class.version).to eq(3)
+      expect(parent_projector_class.version).to eq(3)
+    end
+
+    it 'can override the version without affecting the superclass' do
+      child_projector_class = Class.new(parent_projector_class)
+      child_projector_class.version = 7
+
+      expect(child_projector_class.version).to eq(7)
+      expect(parent_projector_class.version).to eq(3)
+    end
+  end
+
   context 'forward methods' do
     let(:persistor) { double('persistor') }
     let(:record) { double('record') }


### PR DESCRIPTION
Once support for view schema migration versioning is removed this can be replaced by a `class_attribute`, but for now manually default to superclass version if available.