### PR TITLE
Notify callback when an aggregate is loaded that needs a new snapshot

### DIFF
--- a/db/migrate/20251211080900_sequent_overwrite_snapshot_on_conflict.rb
+++ b/db/migrate/20251211080900_sequent_overwrite_snapshot_on_conflict.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SequentOverwriteSnapshotOnConflict < ActiveRecord::Migration[7.2]
+  def up
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute_sql_file 'store_snapshots', version: 3
+    end
+  end
+
+  def down
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute_sql_file 'store_snapshots', version: 2
+    end
+  end
+
+  private
+
+  def execute_sql_file(filename, version:)
+    say "Applying '#{filename}' version #{version}", true
+    suppress_messages do
+      execute File.read(
+        File.join(
+          File.dirname(__FILE__),
+          format('sequent/%s_v%02d.sql', filename, version),
+        ),
+      )
+    end
+  end
+end

--- a/db/migrate/sequent/store_snapshots_v03.sql
+++ b/db/migrate/sequent/store_snapshots_v03.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE PROCEDURE store_snapshots(_snapshots jsonb)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+DECLARE
+  _aggregate_id uuid;
+  _snapshot jsonb;
+  _snapshot_version integer;
+  _sequence_number snapshot_records.sequence_number%TYPE;
+BEGIN
+  FOR _snapshot IN SELECT * FROM jsonb_array_elements(_snapshots) LOOP
+    _aggregate_id = _snapshot->>'aggregate_id';
+    _sequence_number = _snapshot->'sequence_number';
+    _snapshot_version = _snapshot->'snapshot_version';
+
+    INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_version, snapshot_sequence_number_high_water_mark)
+    VALUES (_aggregate_id, _snapshot_version, _sequence_number)
+        ON CONFLICT (aggregate_id, snapshot_version) DO UPDATE
+       SET snapshot_sequence_number_high_water_mark =
+             GREATEST(row.snapshot_sequence_number_high_water_mark, EXCLUDED.snapshot_sequence_number_high_water_mark),
+           snapshot_outdated_at = NULL,
+           snapshot_scheduled_at = NULL;
+
+    INSERT INTO snapshot_records (aggregate_id, snapshot_version, sequence_number, created_at, snapshot_type, snapshot_json)
+    VALUES (
+      _aggregate_id,
+      _snapshot_version,
+      _sequence_number,
+      (_snapshot->>'created_at')::timestamptz,
+      _snapshot->>'snapshot_type',
+      _snapshot->'snapshot_json'
+    )   ON CONFLICT (aggregate_id, snapshot_version, sequence_number) DO UPDATE
+       SET created_at = EXCLUDED.created_at,
+           snapshot_type = EXCLUDED.snapshot_type,
+           snapshot_json = EXCLUDED.snapshot_json
+     WHERE snapshot_records.created_at < EXCLUDED.created_at;
+  END LOOP;
+END;
+$$;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -638,7 +638,11 @@ BEGIN
       (_snapshot->>'created_at')::timestamptz,
       _snapshot->>'snapshot_type',
       _snapshot->'snapshot_json'
-    );
+    )   ON CONFLICT (aggregate_id, snapshot_version, sequence_number) DO UPDATE
+       SET created_at = EXCLUDED.created_at,
+           snapshot_type = EXCLUDED.snapshot_type,
+           snapshot_json = EXCLUDED.snapshot_json
+     WHERE snapshot_records.created_at <= EXCLUDED.created_at;
   END LOOP;
 END;
 $$;
@@ -1572,6 +1576,7 @@ ALTER TABLE ONLY sequent_schema.snapshot_records
 SET search_path TO public,view_schema,sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20251211080900'),
 ('20250815103000'),
 ('20250630113000'),
 ('20250601120000'),

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -77,7 +77,8 @@ module Sequent
                   :aggregate_snapshot_versions,
                   :enable_projector_states,
                   :projectors_replayer_after_prepare_hook,
-                  :projectors_replayer_after_activate_hook
+                  :projectors_replayer_after_activate_hook,
+                  :aggregates_that_need_snapshots_loaded_callback
 
     attr_reader :migrations_class,
                 :versions_table_name

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -867,7 +867,7 @@ describe Sequent::Core::EventStore do
         it 'argument error for no events' do
           expect do |block|
             event_store.stream_events_for_aggregate(aggregate_id_1, load_until: frozen_time - 1.year, &block)
-          end.to raise_error(ArgumentError, 'no events for this aggregate')
+          end.to raise_error(ArgumentError, "no events for aggregate #{aggregate_id_1}")
         end
       end
 

--- a/spec/lib/sequent/core/event_store_spec.rb
+++ b/spec/lib/sequent/core/event_store_spec.rb
@@ -196,6 +196,27 @@ describe Sequent::Core::EventStore do
       )
     end
 
+    it 'overwrites existing snapshot with newer version' do
+      event_store.store_snapshots([snapshot])
+
+      snapshot.created_at += 1
+
+      event_store.store_snapshots([snapshot])
+
+      expect(event_store.load_latest_snapshot(aggregate_id).created_at).to eq(snapshot.created_at)
+    end
+
+    it 'keeps existing snapshot when storing older snapshot' do
+      event_store.store_snapshots([snapshot])
+
+      original_created_at = snapshot.created_at
+      snapshot.created_at -= 1
+
+      event_store.store_snapshots([snapshot])
+
+      expect(event_store.load_latest_snapshot(aggregate_id).created_at).to eq(original_created_at)
+    end
+
     it 'can delete all snapshots' do
       event_store.store_snapshots([snapshot])
 


### PR DESCRIPTION
This allows the user of Sequent to take a snapshot of the aggregate and store it.

You can take the snapshot from the passed in aggregate but must store the snapshot in the same transaction, otherwise non-committed events might be part of the snapshot.

Another option is to reload the aggregate for snapshotting using a separate transaction (for example, using a background job).