### PR TITLE
Use class variables to manage projector states

### DIFF
--- a/lib/sequent/core/projector.rb
+++ b/lib/sequent/core/projector.rb
@@ -9,7 +9,7 @@ module Sequent
     module Migratable
       module ClassMethods
         def manages_tables(*tables)
-          fail 'must specify at least one table to manager' if tables.empty?
+          fail 'must specify at least one table to manage' if tables.empty?
 
           self.managed_tables = tables.freeze
         end


### PR DESCRIPTION
The current setup is complicated and seems to cause flaky tests. Class variables automatically do the right thing (default to parent class if not set on child class, but can be overriden by child class without affecting parent class).