### PR TITLE
Use the ActiveProjectorsEventPublisher to enable projector states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,8 @@
   default version) while new code will only use snapshot version 2.
 
 - Also in preperation of rolling upgrades the enabled projectors are
-  now optionally tracked in the `projector_states` table. Use the
-  `enable_projector_states` configuration flag and
-  `ActiveProjectorsEventPublisher` as the `event_publisher` enable
+  now tracked in the `projector_states` table. Use the
+  `ActiveProjectorsEventPublisher` as the `event_publisher` to enable
   this feature.
 
   Only projectors that are active will process events during normal

--- a/lib/sequent/configuration.rb
+++ b/lib/sequent/configuration.rb
@@ -75,7 +75,6 @@ module Sequent
                   :time_precision,
                   :enable_autoregistration,
                   :aggregate_snapshot_versions,
-                  :enable_projector_states,
                   :projectors_replayer_after_prepare_hook,
                   :projectors_replayer_after_activate_hook
 
@@ -136,7 +135,6 @@ module Sequent
 
       self.enable_autoregistration = false
       self.aggregate_snapshot_versions = DEFAULT_AGGREGATE_SNAPSHOT_VERSIONS
-      self.enable_projector_states = false
     end
 
     def versions_table_name=(table_name)

--- a/lib/sequent/core/active_projectors_event_publisher.rb
+++ b/lib/sequent/core/active_projectors_event_publisher.rb
@@ -49,9 +49,6 @@ module Sequent
         version = handler.class.version
         return true if version.nil?
 
-        # Projector states are not enable so all projectors are considered active
-        return true unless Sequent.configuration.enable_projector_states
-
         projector_state = Projectors.projector_states[handler.class.name]
         return false if projector_state.nil?
 

--- a/spec/lib/sequent/core/event_publisher_spec.rb
+++ b/spec/lib/sequent/core/event_publisher_spec.rb
@@ -75,7 +75,6 @@ describe Sequent::Core::EventPublisher do
   context Sequent::Core::ActiveProjectorsEventPublisher do
     before do
       Sequent::Configuration.reset
-      Sequent.configuration.enable_projector_states = true
       Sequent.configuration.event_publisher = Sequent::Core::ActiveProjectorsEventPublisher.new
     end
     after { Sequent::Configuration.reset }

--- a/spec/lib/sequent/migrations/projectors_replayer_spec.rb
+++ b/spec/lib/sequent/migrations/projectors_replayer_spec.rb
@@ -11,7 +11,6 @@ describe Sequent::Migrations::ProjectorsReplayer do
     Sequent::Core::ProjectorState.delete_all
 
     Sequent.configuration.event_handlers = [SingleRecordProjector.new]
-    Sequent.configuration.enable_projector_states = true
     Sequent.configuration.event_publisher = Sequent::Core::ActiveProjectorsEventPublisher.new
     Sequent.configuration.migrations_class = SpecMigrations
     SpecMigrations.version = 0

--- a/spec/lib/sequent/migrations/view_schema_spec.rb
+++ b/spec/lib/sequent/migrations/view_schema_spec.rb
@@ -348,7 +348,6 @@ describe Sequent::Migrations::ViewSchema do
     let(:new_version) { SpecMigrations.version }
     let(:configure_sequent) do
       Sequent.configure do |config|
-        config.enable_projector_states = true
         config.migration_sql_files_directory = 'spec/fixtures/db/1'
         config.migrations_class = SpecMigrations
       end
@@ -402,7 +401,6 @@ describe Sequent::Migrations::ViewSchema do
         wait_for_persisted_events_to_become_visible_for_online_migration[]
 
         Sequent.configure do |config|
-          config.enable_projector_states = true
           config.migration_sql_files_directory = 'spec/fixtures/db/1'
           config.migrations_class = SpecMigrations
         end


### PR DESCRIPTION
The `ActiveProjectorsEventPublisher` checks if a projector is active before publishing events so the old `enable_projector_states` flag is not needed.