### PR TITLE
Mark the test/time_comparison module as deprecated

### DIFF
--- a/lib/sequent/test/time_comparison.rb
+++ b/lib/sequent/test/time_comparison.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+warn '[DEPRECATED] sequent/test/time_comparison monkey-patches standard time related classes'
+
 module Sequent
   module Test
     module DateTimePatches


### PR DESCRIPTION
This module monkey-patches various time related classes which breaks the `<=>` method. Use `Timecop` if you need to compare timestamps in tests.