### PR TITLE
Make `upcast!` public so it can be used outside of deserialization

### DIFF
--- a/lib/sequent/core/helpers/attribute_support.rb
+++ b/lib/sequent/core/helpers/attribute_support.rb
@@ -123,8 +123,18 @@ EOS
           end
 
           def upcast(&block)
+            fail 'block is required' unless block
+
             @upcasters ||= []
             @upcasters.push(block)
+          end
+
+          def upcast!(hash)
+            return if @upcasters.nil?
+
+            @upcasters.each do |upcaster|
+              upcaster.call(hash)
+            end
           end
 
           private
@@ -137,14 +147,6 @@ EOS
               .reduce(merged_types) do |memo, mod|
                 memo.merge(mod.types)
               end
-          end
-
-          def upcast!(hash)
-            return if @upcasters.nil?
-
-            @upcasters.each do |upcaster|
-              upcaster.call(hash)
-            end
           end
 
           def validate_attrs!(args)


### PR DESCRIPTION
This allows other code to generically work with the raw JSON representation without having to worry about older formats.