### PR TITLE
Add `before_commit` hook to transaction provider

### DIFF
--- a/lib/sequent/core/transactions/active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/active_record_transaction_provider.rb
@@ -48,12 +48,16 @@ module Sequent
         # Deprecated alias
         alias transactional transaction
 
+        def before_commit(&block)
+          ActiveRecord::Base.connection.current_transaction.before_commit(&block)
+        end
+
         def after_commit(&block)
-          ActiveRecord::Base.current_transaction.after_commit(&block)
+          ActiveRecord::Base.connection.current_transaction.after_commit(&block)
         end
 
         def after_rollback(&block)
-          ActiveRecord::Base.current_transaction.after_rollback(&block)
+          ActiveRecord::Base.connection.current_transaction.after_rollback(&block)
         end
       end
     end

--- a/lib/sequent/core/transactions/no_transactions.rb
+++ b/lib/sequent/core/transactions/no_transactions.rb
@@ -16,6 +16,7 @@ module Sequent
         # Deprecated alias
         alias transactional transaction
 
+        def before_commit = yield
         def after_commit = yield
         def after_rollback = nil
       end

--- a/lib/sequent/core/transactions/read_only_active_record_transaction_provider.rb
+++ b/lib/sequent/core/transactions/read_only_active_record_transaction_provider.rb
@@ -22,7 +22,7 @@ module Sequent
         # Deprecated
         alias transactional transaction
 
-        delegate :after_commit, :after_rollback, to: :@transaction_provider
+        delegate :before_commit, :after_commit, :after_rollback, to: :@transaction_provider
 
         private
 

--- a/spec/lib/sequent/core/transactions/active_record_transaction_provider_spec.rb
+++ b/spec/lib/sequent/core/transactions/active_record_transaction_provider_spec.rb
@@ -9,6 +9,35 @@ describe Sequent::Core::Transactions::ActiveRecordTransactionProvider do
     expect(provider.transaction { '10' }).to eq '10'
   end
 
+  context 'with before_commit hooks' do
+    it 'calls the before_commit hooks' do
+      called = false
+      provider.transaction do
+        provider.before_commit { called = true }
+      end
+      expect(called).to be_truthy
+    end
+    it 'still returns the result of the block' do
+      called = false
+      result = provider.transaction do
+        provider.before_commit { called = true }
+        '11'
+      end
+      expect(called).to be_truthy
+      expect(result).to eq('11')
+    end
+    it 'only calls before_commit when the outermost transaction completes' do
+      called = false
+      provider.transaction do
+        provider.transaction do
+          provider.before_commit { called = true }
+        end
+        expect(called).to be_falsy
+      end
+      expect(called).to be_truthy
+    end
+  end
+
   context 'with after_commit hooks' do
     it 'calls the after_commit hooks' do
       called = false


### PR DESCRIPTION
The `before_commit` hook is exposed in ActiveRecord using the underlying transaction adapter which can be accessed through the current database connection.