### PR TITLE
New snapshot versions are marked as outdated on registration

### DIFF
--- a/db/migrate/20260610094300_sequent_fix_snapshot_version_upgrades.rb
+++ b/db/migrate/20260610094300_sequent_fix_snapshot_version_upgrades.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class SequentFixSnapshotVersionUpgrades < ActiveRecord::Migration[7.2]
+  def up
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute_sql_file 'store_snapshots', version: 3
+    end
+  end
+
+  def down
+    Sequent::Support::Database.with_search_path(Sequent.configuration.event_store_schema_name) do
+      execute_sql_file 'store_snapshots', version: 2
+    end
+  end
+
+  private
+
+  def execute_sql_file(filename, version:)
+    say "Applying '#{filename}' version #{version}", true
+    suppress_messages do
+      execute File.read(
+        File.join(
+          File.dirname(__FILE__),
+          format('sequent/%s_v%02d.sql', filename, version),
+        ),
+      )
+    end
+  end
+end

--- a/db/migrate/sequent/store_snapshots_v03.sql
+++ b/db/migrate/sequent/store_snapshots_v03.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE PROCEDURE store_snapshots(_snapshots jsonb)
+LANGUAGE plpgsql SET search_path FROM CURRENT AS $$
+DECLARE
+  _aggregate_id uuid;
+  _snapshot jsonb;
+  _snapshot_version integer;
+  _sequence_number snapshot_records.sequence_number%TYPE;
+BEGIN
+  FOR _snapshot IN SELECT * FROM jsonb_array_elements(_snapshots) LOOP
+    _aggregate_id = _snapshot->>'aggregate_id';
+    _sequence_number = _snapshot->'sequence_number';
+    _snapshot_version = _snapshot->'snapshot_version';
+
+    INSERT INTO aggregates_that_need_snapshots AS row (aggregate_id, snapshot_version, snapshot_sequence_number_high_water_mark)
+    VALUES (_aggregate_id, _snapshot_version, _sequence_number)
+        ON CONFLICT (aggregate_id, snapshot_version) DO UPDATE
+       SET snapshot_sequence_number_high_water_mark =
+             GREATEST(row.snapshot_sequence_number_high_water_mark, EXCLUDED.snapshot_sequence_number_high_water_mark),
+           snapshot_outdated_at = NULL,
+           snapshot_scheduled_at = NULL;
+
+    INSERT INTO snapshot_records (aggregate_id, snapshot_version, sequence_number, created_at, snapshot_type, snapshot_json)
+    VALUES (
+      _aggregate_id,
+      _snapshot_version,
+      _sequence_number,
+      (_snapshot->>'created_at')::timestamptz,
+      _snapshot->>'snapshot_type',
+      _snapshot->'snapshot_json'
+    )
+        ON CONFLICT (aggregate_id, snapshot_version, sequence_number) DO UPDATE
+       SET created_at = EXCLUDED.created_at,
+           snapshot_type = EXCLUDED.snapshot_type,
+           snapshot_json = EXCLUDED.snapshot_json;
+  END LOOP;
+END;
+$$;

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -638,7 +638,11 @@ BEGIN
       (_snapshot->>'created_at')::timestamptz,
       _snapshot->>'snapshot_type',
       _snapshot->'snapshot_json'
-    );
+    )
+        ON CONFLICT (aggregate_id, snapshot_version, sequence_number) DO UPDATE
+       SET created_at = EXCLUDED.created_at,
+           snapshot_type = EXCLUDED.snapshot_type,
+           snapshot_json = EXCLUDED.snapshot_json;
   END LOOP;
 END;
 $$;
@@ -1588,6 +1592,7 @@ ALTER TABLE ONLY sequent_schema.snapshot_records
 SET search_path TO public,view_schema,sequent_schema;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260610094300'),
 ('20260226121600'),
 ('20260129130000'),
 ('20250815103000'),

--- a/lib/sequent/core/snapshot_store.rb
+++ b/lib/sequent/core/snapshot_store.rb
@@ -59,7 +59,7 @@ module Sequent
                       )
           SELECT s.aggregate_id,
                  s.snapshot_sequence_number_high_water_mark,
-                 s.snapshot_outdated_at,
+                 COALESCE(s.snapshot_outdated_at, NOW()),
                  ($1::jsonb->(t.type))::integer
             FROM existing_versions s
             JOIN aggregates a ON s.aggregate_id = a.aggregate_id


### PR DESCRIPTION
This ensures these aggregates will be snapshotted again so the new version is stored.

Also allow storing a snapshot for the same aggregate, version, and sequence number by simply overwriting the existing snapshot.